### PR TITLE
Configurable colors (fixes #5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,7 @@ name = "cargo-audit"
 version = "0.1.1"
 dependencies = [
  "clap 2.20.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustsec 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ name = "cargo-audit"
 
 [dependencies]
 clap = "^2"
+libc = "^0.2"
 rustsec = "^0.5.2"
 semver = "^0.6"
 term = "^0.4"

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,85 +1,255 @@
+//! Terminal handling code
+//!
+//! Some portions borrowed from the Cargo project: https://github.com/rust-lang/cargo
+//! These portions are redistributed under the same license as Cargo (shared by cargo-audit itself)
+
+use libc;
 use lockfile::Package;
 use rustsec::advisory::Advisory;
-use term::{self, Attr, Terminal};
-use term::color::{self, Color};
+use std::fmt;
+use std::io;
+use std::io::prelude::*;
+use term::{self, TerminfoTerminal, Attr};
+use term::Terminal as RawTerminal;
+use term::color::{Color, BLACK, WHITE, RED};
 
-// TODO: Macros, cleaner API, support for disabling colors (possibly using Cargo settings?)
-// Cargo's `Shell` type may be useful here
-pub fn notify<T>(terminal: &mut Box<T>,
-                 color: Color,
-                 status: &str,
-                 message: &str)
-                 -> term::Result<()>
-    where T: Terminal + ?Sized
-{
-    terminal.attr(Attr::Bold)?;
-    terminal.fg(color)?;
-    write!(terminal, "{:>12}", status)?;
-
-    terminal.reset()?;
-    write!(terminal, " {}\n", message)?;
-
-    terminal.flush()?;
-    Ok(())
+#[derive(Clone, Copy, PartialEq)]
+pub enum ColorConfig {
+    Auto,
+    Always,
+    Never,
 }
 
-pub fn not_found<T>(terminal: &mut Box<T>, filename: &str) -> term::Result<()>
-    where T: Terminal + ?Sized
-{
-    terminal.attr(Attr::Bold)?;
-    terminal.fg(color::RED)?;
-    write!(terminal, "error: ")?;
-
-    terminal.reset()?;
-    terminal.attr(Attr::Bold)?;
-    writeln!(terminal, "Couldn't find '{}'!", filename)?;
-
-    terminal.reset()?;
-    writeln!(terminal,
-             "\nRun \"cargo build\" to generate lockfile before running audit")?;
-
-    terminal.flush()?;
-    Ok(())
+impl fmt::Display for ColorConfig {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+                ColorConfig::Auto => "auto",
+                ColorConfig::Always => "always",
+                ColorConfig::Never => "never",
+            }
+            .fmt(f)
+    }
 }
 
-pub fn vulns_found<T>(terminal: &mut Box<T>, vuln_count: usize) -> term::Result<()>
-    where T: Terminal + ?Sized
-{
-    terminal.attr(Attr::Bold)?;
-    terminal.fg(color::RED)?;
+#[derive(Clone, Copy)]
+pub struct ShellConfig {
+    pub color_config: ColorConfig,
+    pub tty: bool,
+}
 
-    if vuln_count == 1 {
-        write!(terminal, "\n1 vulnerability found!\n")?;
-    } else {
-        write!(terminal, "\n{} vulnerabilities found!\n", vuln_count)?;
+enum Terminal {
+    NoColor(Box<Write + Send>),
+    Colored(Box<RawTerminal<Output = Box<Write + Send>> + Send>),
+}
+
+pub struct Shell {
+    terminal: Terminal,
+    config: ShellConfig,
+}
+
+impl Shell {
+    pub fn create<T: FnMut() -> Box<Write + Send>>(mut out_fn: T, config: ShellConfig) -> Shell {
+        let term = match Shell::get_term(out_fn()) {
+            Ok(t) => t,
+            Err(_) => Terminal::NoColor(out_fn()),
+        };
+
+        Shell {
+            terminal: term,
+            config: config,
+        }
     }
 
-    terminal.reset()?;
-    terminal.flush()?;
+    #[cfg(any(windows))]
+    fn get_term(out: Box<Write + Send>) -> term::Result<Terminal> {
+        // Check if the creation of a console will succeed
+        if ::term::WinConsole::new(vec![0u8; 0]).is_ok() {
+            let t = ::term::WinConsole::new(out)?;
+            if !t.supports_color() {
+                Ok(NoColor(Box::new(t)))
+            } else {
+                Ok(Colored(Box::new(t)))
+            }
+        } else {
+            // If we fail to get a windows console, we try to get a `TermInfo` one
+            Ok(Shell::get_terminfo_term(out))
+        }
+    }
+
+    #[cfg(any(unix))]
+    fn get_term(out: Box<Write + Send>) -> term::Result<Terminal> {
+        Ok(Shell::get_terminfo_term(out))
+    }
+
+    fn get_terminfo_term(out: Box<Write + Send>) -> Terminal {
+        // Use `TermInfo::from_env()` and `TerminfoTerminal::supports_color()`
+        // to determine if creation of a TerminfoTerminal is possible regardless
+        // of the tty status. --color options are parsed after Shell creation so
+        // always try to create a terminal that supports color output. Fall back
+        // to a no-color terminal regardless of whether or not a tty is present
+        // and if color output is not possible.
+        match ::term::terminfo::TermInfo::from_env() {
+            Ok(ti) => {
+                let term = TerminfoTerminal::new_with_terminfo(out, ti);
+                if !term.supports_color() {
+                    Terminal::NoColor(term.into_inner())
+                } else {
+                    // Color output is possible.
+                    Terminal::Colored(Box::new(term))
+                }
+            }
+            Err(_) => Terminal::NoColor(out),
+        }
+    }
+
+    pub fn say<T: ToString>(&mut self, message: T, color: Color) -> term::Result<()> {
+        self.reset()?;
+
+        if color != BLACK {
+            self.fg(color)?;
+        }
+
+        write!(self, "{}\n", message.to_string())?;
+        self.reset()?;
+        self.flush()?;
+
+        Ok(())
+    }
+
+    pub fn say_status<T, U>(&mut self,
+                            status: T,
+                            message: U,
+                            color: Color,
+                            justified: bool)
+                            -> term::Result<()>
+        where T: fmt::Display,
+              U: fmt::Display
+    {
+        self.reset()?;
+        if color != BLACK {
+            self.fg(color)?;
+        }
+        if self.supports_attr(Attr::Bold) {
+            self.attr(Attr::Bold)?;
+        }
+        if justified {
+            write!(self, "{:>12}", status.to_string())?;
+        } else {
+            write!(self, "{}", status)?;
+        }
+        self.reset()?;
+        write!(self, " {}\n", message)?;
+        self.flush()?;
+        Ok(())
+    }
+
+    fn fg(&mut self, color: Color) -> term::Result<bool> {
+        let colored = self.colored();
+
+        match self.terminal {
+            Terminal::Colored(ref mut c) if colored => c.fg(color)?,
+            _ => return Ok(false),
+        }
+        Ok(true)
+    }
+
+    fn attr(&mut self, attr: Attr) -> term::Result<bool> {
+        let colored = self.colored();
+
+        match self.terminal {
+            Terminal::Colored(ref mut c) if colored => c.attr(attr)?,
+            _ => return Ok(false),
+        }
+        Ok(true)
+    }
+
+    fn supports_attr(&self, attr: Attr) -> bool {
+        let colored = self.colored();
+
+        match self.terminal {
+            Terminal::Colored(ref c) if colored => c.supports_attr(attr),
+            _ => false,
+        }
+    }
+
+    fn reset(&mut self) -> term::Result<()> {
+        let colored = self.colored();
+
+        match self.terminal {
+            Terminal::Colored(ref mut c) if colored => c.reset()?,
+            _ => (),
+        }
+        Ok(())
+    }
+
+    fn colored(&self) -> bool {
+        self.config.tty && ColorConfig::Auto == self.config.color_config ||
+        ColorConfig::Always == self.config.color_config
+    }
+}
+
+impl Write for Shell {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self.terminal {
+            Terminal::Colored(ref mut c) => c.write(buf),
+            Terminal::NoColor(ref mut n) => n.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self.terminal {
+            Terminal::Colored(ref mut c) => c.flush(),
+            Terminal::NoColor(ref mut n) => n.flush(),
+        }
+    }
+}
+
+pub fn shell(color_config: ColorConfig) -> Shell {
+    let config = ShellConfig {
+        color_config: color_config,
+        tty: isatty(),
+    };
+    Shell::create(|| Box::new(io::stdout()), config)
+}
+
+pub fn not_found(shell: &mut Shell, filename: &str) -> term::Result<()> {
+    shell.say_status("error:",
+                    format!("Couldn't find '{}'!", filename),
+                    RED,
+                    false)?;
+    shell.say("\nRun \"cargo build\" to generate lockfile before running audit",
+             WHITE)?;
+
     Ok(())
 }
 
-pub fn advisory<T>(terminal: &mut Box<T>,
-                   package: &Package,
-                   advisory: &Advisory)
-                   -> term::Result<()>
-    where T: Terminal + ?Sized
-{
-    write!(terminal, "\n")?;
+pub fn vulns_found(shell: &mut Shell, vuln_count: usize) -> term::Result<()> {
+    shell.fg(RED)?;
+    shell.attr(Attr::Bold)?;
 
-    attribute(terminal, "ID", &advisory.id)?;
-    attribute(terminal, "Crate", &package.name)?;
-    attribute(terminal, "Version", &package.version)?;
+    if vuln_count == 1 {
+        write!(shell, "\n1 vulnerability found!\n")?;
+    } else {
+        write!(shell, "\n{} vulnerabilities found!\n", vuln_count)?;
+    }
+
+    Ok(())
+}
+
+pub fn advisory(shell: &mut Shell, package: &Package, advisory: &Advisory) -> term::Result<()> {
+    attribute(shell, "\nID", &advisory.id)?;
+    attribute(shell, "Crate", &package.name)?;
+    attribute(shell, "Version", &package.version)?;
 
     if let Some(ref date) = advisory.date {
-        attribute(terminal, "Date", date)?;
+        attribute(shell, "Date", date)?;
     }
 
     if let Some(ref url) = advisory.url {
-        attribute(terminal, "URL", url)?;
+        attribute(shell, "URL", url)?;
     }
 
-    attribute(terminal, "Title", &advisory.title)?;
+    attribute(shell, "Title", &advisory.title)?;
 
     let mut fixed_versions = String::new();
     let version_count = advisory.patched_versions.len();
@@ -92,26 +262,27 @@ pub fn advisory<T>(terminal: &mut Box<T>,
         }
     }
 
-    attribute(terminal, "Solution: upgrade to", &fixed_versions)?;
-
-    terminal.reset()?;
-    terminal.flush()?;
+    attribute(shell, "Solution: upgrade to", &fixed_versions)?;
 
     Ok(())
 }
 
-fn attribute<T>(terminal: &mut Box<T>, name: &str, value: &str) -> term::Result<()>
-    where T: Terminal + ?Sized
-{
-    terminal.attr(Attr::Bold)?;
-    terminal.fg(color::RED)?;
-    write!(terminal, "{}: ", name)?;
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn isatty() -> bool {
+    unsafe { libc::isatty(libc::STDOUT_FILENO) != 0 }
+}
 
-    terminal.reset()?;
-    terminal.attr(Attr::Bold)?;
-    write!(terminal, "{}\n", value)?;
+fn attribute(shell: &mut Shell, name: &str, value: &str) -> term::Result<()> {
+    shell.attr(Attr::Bold)?;
+    shell.fg(RED)?;
+    write!(shell, "{}: ", name)?;
 
-    terminal.reset()?;
+    shell.reset()?;
+    shell.attr(Attr::Bold)?;
+    write!(shell, "{}\n", value)?;
+
+    shell.reset()?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,58 +11,65 @@ mod display;
 mod lockfile;
 
 extern crate clap;
+extern crate libc;
 extern crate rustsec;
 extern crate semver;
 extern crate term;
 extern crate toml;
 
-use clap::{App, SubCommand};
+use clap::{App, Arg, SubCommand};
+use display::ColorConfig;
 use rustsec::AdvisoryDatabase;
 use std::process::exit;
+use term::color::{RED, GREEN};
 
 fn main() {
-    let mut stdout = term::stdout().unwrap();
-
     let matches = App::new("cargo")
         .subcommand(SubCommand::with_name("audit")
             .version(env!("CARGO_PKG_VERSION"))
             .author("Tony Arcieri <bascule@gmail.com>")
             .about("Audit Cargo.lock for crates with security vulnerabilities.")
             .arg_from_usage("-f, --file=[NAME] 'Cargo lockfile to inspect (default: Cargo.lock)'")
-            .arg_from_usage("-u, --url=[URL] 'URL from which to fetch advisory database'"))
+            .arg_from_usage("-u, --url=[URL] 'URL from which to fetch advisory database'")
+            .arg(Arg::from_usage("--color=[COLOR] Colored output")
+                .possible_values(&["auto", "always", "never"])))
         .get_matches();
 
-    let (filename, url) = if let Some(audit_matches) = matches.subcommand_matches("audit") {
+    let (filename, url, color_config) = if let Some(audit_matches) =
+        matches.subcommand_matches("audit") {
         (audit_matches.value_of("file").unwrap_or("Cargo.lock"),
-         audit_matches.value_of("url").unwrap_or(rustsec::ADVISORY_DB_URL))
+         audit_matches.value_of("url").unwrap_or(rustsec::ADVISORY_DB_URL),
+         audit_matches.value_of("color").unwrap_or("auto"))
     } else {
         panic!("cargo-audit is intended to be invoked as a cargo subcommand");
     };
 
+    let mut shell = display::shell(match color_config {
+        "always" => ColorConfig::Always,
+        "never" => ColorConfig::Never,
+        _ => ColorConfig::Auto,
+    });
+
     let dependencies_result = lockfile::load(filename);
 
     if !dependencies_result.is_ok() {
-        display::not_found(&mut stdout, filename).unwrap();
+        display::not_found(&mut shell, filename).unwrap();
         exit(1);
     };
 
     let dependencies = dependencies_result.unwrap();
 
-    display::notify(&mut stdout,
-                    term::color::GREEN,
-                    "Fetching",
-                    &format!("advisories `{}`", url))
-        .unwrap();
+    shell.say_status("Fetching", &format!("advisories `{}`", url), GREEN, true).unwrap();
 
     let advisory_db = AdvisoryDatabase::fetch_from_url(url)
         .expect("Couldn't fetch advisory database");
 
-    display::notify(&mut stdout,
-                    term::color::GREEN,
-                    "Scanning",
+    shell.say_status("Scanning",
                     &format!("{} crates for vulnerabilities ({} advisories in database)",
                              dependencies.len(),
-                             advisory_db.iter().len()))
+                             advisory_db.iter().len()),
+                    GREEN,
+                    true)
         .unwrap();
 
     let mut vuln_count: usize = 0;
@@ -72,30 +79,24 @@ fn main() {
             .expect("error obtaining advisories for this crate");
 
         if vuln_count == 0 && !advisories.is_empty() {
-            display::notify(&mut stdout,
-                            term::color::RED,
-                            "Warning",
-                            "Vulnerable crates found!")
+            shell.say_status("Warning", "Vulnerable crates found!", RED, true)
                 .unwrap()
         }
 
         vuln_count += advisories.len();
 
         for advisory in advisories {
-            display::advisory(&mut stdout, &package, advisory).unwrap();
+            display::advisory(&mut shell, &package, advisory).unwrap();
         }
     }
 
     if vuln_count == 0 {
-        display::notify(&mut stdout,
-                        term::color::GREEN,
-                        "Success",
-                        "No vulnerable packages found")
+        shell.say_status("Success", "No vulnerable packages found", GREEN, true)
             .unwrap();
 
         exit(0);
     } else {
-        display::vulns_found(&mut stdout, vuln_count).unwrap();
+        display::vulns_found(&mut shell, vuln_count).unwrap();
         exit(1);
     }
 }


### PR DESCRIPTION
This commit borrows some color/terminal handling code from cargo (with the hopes
of eventually getting this code merged into cargo proper).

Color support is now autodetected but also configurable as a "--color" command
line parameter (ala cargo itself)