### PR TITLE
Use ' OR ' delimiter to display patched versions (fixes #18)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -213,13 +213,15 @@ fn display_advisory(package: &Package, advisory: &Advisory) {
     }
 
     attribute!("Title", &advisory.title);
-
-    let mut versions_iter = advisory.patched_versions.iter();
-    let mut patched_versions = versions_iter.next().unwrap().to_string();
-
-    for version in versions_iter {
-        patched_versions = patched_versions + ", " + &version.to_string();
-    }
-
-    attribute!("Solution: upgrade to", &patched_versions);
+    attribute!(
+        "Solution",
+        "upgrade to: {}",
+        advisory
+            .patched_versions
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .as_slice()
+            .join(" OR ")
+    );
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -52,19 +52,21 @@ where
 
 /// Print an attribute of an advisory
 macro_rules! attribute {
-    ($attr:expr, $value:expr) => {
+    ($attr:expr, $msg:expr) => {
         ::shell::status(
             ::term::color::RED,
-            // HAX!
-            if $attr == "Version" || $attr == "Solution: upgrade to" {
+            if $attr.len() >= 7 {
                 format!("{}:", $attr)
             } else {
                 format!("{}:\t", $attr)
             },
-            $value,
+            $msg,
             false,
         );
     };
+    ($attr: expr, $fmt:expr, $($arg:tt)+) => {
+        attribute!($attr, format!($fmt, $($arg)+));
+    }
 }
 
 /// Print a success status message (in green if colors are enabled)


### PR DESCRIPTION
This makes usage of commas in `VersionReq`s less ambiguous