### PR TITLE
Have 'cargo audit version' exit with status 0

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -159,7 +159,7 @@ fn version() -> ! {
         " ",
         env!("CARGO_PKG_VERSION")
     ));
-    exit(2);
+    exit(0);
 }
 
 /// Load the advisory database


### PR DESCRIPTION
This shouldn't exit with an error (e.g. breaks in CI)