### PR TITLE
Allows macro_use that is unused on beta channel

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@
 mod shell;
 
 extern crate gumdrop;
+#[allow(unused_imports)]
 #[macro_use]
 extern crate gumdrop_derive;
 extern crate isatty;


### PR DESCRIPTION
Beta channel builds were failing on this from the `deny(warnings)`. This enables building against all of 1.25.0, stable, and beta as of the present.