### PR TITLE
Bumps minimum Rust version on Travis to 1.26.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ branches:
     - master
 
 rust:
-  - 1.25.0
+  - 1.26.2
   - stable
   - beta
   - nightly


### PR DESCRIPTION
This is necessary to pick up some functions introduced in 1.26.0 that transitive dependency libssh2-sys-0.2.11 requires.

Unblocks a #48, which unblocks #41.