### PR TITLE
Fixes macro_use and bumps to 1.26.2 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ branches:
     - master
 
 rust:
-  - 1.25.0
+  - 1.26.2
   - stable
   - beta
   - nightly

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@
 mod shell;
 
 extern crate gumdrop;
+#[allow(unused_imports)]
 #[macro_use]
 extern crate gumdrop_derive;
 extern crate isatty;


### PR DESCRIPTION
Supercedes #48 and #49 and should close both when merged.