### PR TITLE
README.md: Document use of "cache: cargo" on Travis CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ To automaticlly run `cargo audit` on every build in Travis CI, you can add the f
 
 ```yaml
 language: rust
+cache: cargo # cache cargo-audit once installed
 before_script:
   - cargo install --force cargo-audit
   - cargo generate-lockfile


### PR DESCRIPTION
Improves performance after `cargo-audit` has been installed the first time