### PR TITLE
Update gumdrop and rustsec crate dependencies; Rust 1.32+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,11 +64,10 @@ version = "0.6.1"
 dependencies = [
  "assert_cmd 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "gumdrop 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gumdrop_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gumdrop 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "platforms 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustsec 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustsec 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "serial_test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serial_test_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -184,20 +183,20 @@ dependencies = [
 
 [[package]]
 name = "gumdrop"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gumdrop_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gumdrop_derive 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gumdrop_derive"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -503,19 +502,17 @@ dependencies = [
 
 [[package]]
 name = "rustsec"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "directories 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "platforms 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -589,16 +586,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.14.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "syn"
 version = "0.15.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -662,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.4.10"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -748,8 +735,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum git2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7339329bfa14a00223244311560d11f8f489b453fb90092af97f267a6090ab0"
-"checksum gumdrop 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "395c7c79599167d04e7349ee60cc6cb14a28dfebaf922b4dc41603a7b18c3b28"
-"checksum gumdrop_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "04c43663fd6604d9065f5cd26ae7a0301491fd941ad29b0a01665a6be3a1ddbd"
+"checksum gumdrop 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a57b4113bb9af093a1cd0b505a44a93103e32e258296d01fa2def3f37c2c7cc"
+"checksum gumdrop_derive 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dae5488e2c090f7586e2027e4ea6fcf8c9d83e2ef64d623993a33a0fb811f1f7"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
@@ -787,7 +774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-"checksum rustsec 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e8ef87a5c8c9ad823ed2203ccef6c19005f80dbc55f84181200396aae2fc0b41"
+"checksum rustsec 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b7e26e0c0a0c30a772d2749e241242d37f712c84d5626b760c661341bcfbc92"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
@@ -797,14 +784,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serial_test 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50bfbc39343545618d97869d77f38ed43e48dd77432717dbc7ed39d797f3ecbe"
 "checksum serial_test_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "89dd85be2e2ad75b041c9df2892ac078fa6e0b90024028b2b9fb4125b7530f01"
 "checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
-"checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
 "checksum syn 0.15.27 (registry+https://github.com/rust-lang/crates.io-index)" = "525bd55255f03c816e5d7f615587bd13030c7103354fadb104993dcee6a788ec"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7dc4738f2e68ed2855de5ac9cdbe05c9216773ecde4739b2f095002ab03a13ef"
 "checksum term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
-"checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
+"checksum toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b8c96d7873fa7ef8bdeb3a9cda3ac48389b4154f32b9803b4bc26220b677b039"
 "checksum treeline 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,10 @@ name = "cargo-audit"
 
 [dependencies]
 atty = "0.2"
-gumdrop = "0.5"
-gumdrop_derive = "0.5"
+gumdrop = "0.6"
 lazy_static = "1"
 platforms = "0.2"
-rustsec = "0.11"
+rustsec = "0.12"
 term = "0.5"
 serde_json = "1"
 

--- a/README.md
+++ b/README.md
@@ -3,18 +3,10 @@
 [![Latest Version][crate-image]][crate-link]
 [![Build Status][build-image]][build-link]
 [![Appveyor Status][appveyor-image]][appveyor-link]
+![forbid(unsafe_code)][unsafe-image]
+![Rust 1.35+][rustc-image]
 ![Apache 2.0 OR MIT licensed][license-image]
 [![Gitter Chat][gitter-image]][gitter-link]
-
-[crate-image]: https://img.shields.io/crates/v/cargo-audit.svg
-[crate-link]: https://crates.io/crates/cargo-audit
-[build-image]: https://travis-ci.org/RustSec/cargo-audit.svg?branch=master
-[build-link]: https://travis-ci.org/RustSec/cargo-audit
-[appveyor-image]: https://ci.appveyor.com/api/projects/status/oa39c0in9qkxpoiv?svg=true
-[appveyor-link]: https://ci.appveyor.com/project/tarcieri/cargo-audit
-[license-image]: https://img.shields.io/badge/license-Apache2.0%2FMIT-blue.svg
-[gitter-image]: https://badges.gitter.im/badge.svg
-[gitter-link]: https://gitter.im/RustSec/Lobby
 
 Audit Cargo.lock for crates with security vulnerabilities reported to the
 [RustSec Advisory Database].
@@ -25,7 +17,7 @@ https://github.com/rust-lang/rfcs/pull/1752
 
 ## Requirements
 
-`cargo audit` requires Rust **1.31** or later.
+`cargo audit` requires Rust **1.32** or later.
 
 ## Installation
 
@@ -78,6 +70,22 @@ at your option.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you shall be dual licensed as above, without any
 additional terms or conditions.
+
+[//]: # (badges)
+
+[crate-image]: https://img.shields.io/crates/v/cargo-audit.svg
+[crate-link]: https://crates.io/crates/cargo-audit
+[build-image]: https://travis-ci.org/RustSec/cargo-audit.svg?branch=master
+[build-link]: https://travis-ci.org/RustSec/cargo-audit
+[appveyor-image]: https://ci.appveyor.com/api/projects/status/oa39c0in9qkxpoiv?svg=true
+[appveyor-link]: https://ci.appveyor.com/project/tarcieri/cargo-audit
+[license-image]: https://img.shields.io/badge/license-Apache2.0%2FMIT-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.32+-blue.svg
+[unsafe-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
+[gitter-image]: https://badges.gitter.im/badge.svg
+[gitter-link]: https://gitter.im/RustSec/Lobby
+
+[//]: # (general links)
 
 [RustSec Advisory Database]: https://github.com/RustSec/advisory-db/
 [LICENSE-APACHE]: https://github.com/RustSec/cargo-audit/blob/master/LICENSE-APACHE

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,25 +1,10 @@
 //! Audit Cargo.lock files for crates containing security vulnerabilities
 
-#![crate_name = "cargo_audit"]
-#![crate_type = "bin"]
-#![deny(unsafe_code, warnings, missing_docs, trivial_numeric_casts)]
-#![deny(trivial_casts, unused_import_braces, unused_qualifications)]
+#![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
+#![forbid(unsafe_code)]
 
 #[macro_use]
 mod shell;
-
-extern crate gumdrop;
-#[allow(unused_imports)]
-#[macro_use]
-extern crate gumdrop_derive;
-extern crate atty;
-#[macro_use]
-extern crate lazy_static;
-extern crate platforms;
-extern crate rustsec;
-extern crate term;
-#[macro_use]
-extern crate serde_json;
 
 use gumdrop::Options;
 use platforms::target::{Arch, OS};
@@ -32,6 +17,7 @@ use std::{
     path::{Path, PathBuf},
     process::exit,
 };
+use serde_json::json;
 
 /// Name of `Cargo.lock`
 const CARGO_LOCK_FILE: &str = "Cargo.lock";

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -15,6 +15,7 @@ use term::{
     color::{Color, BLACK},
     Attr, Terminal as TermTerminal, TerminfoTerminal,
 };
+use lazy_static::lazy_static;
 
 lazy_static! {
     static ref SHELL: Mutex<RefCell<Option<Shell>>> = Mutex::new(RefCell::new(None));

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -49,8 +49,7 @@ fn assert_advisories(command: &mut Command, expected_advisories: Vec<&str>) {
 }
 
 fn assert_advisory_output(output: &std::process::Output, expected_advisories: Vec<&str>) {
-    let json: serde_json::Value =
-        serde_json::from_slice(output.stdout.as_slice()).unwrap();
+    let json: serde_json::Value = serde_json::from_slice(output.stdout.as_slice()).unwrap();
 
     // Example JSON structure:
     //
@@ -144,7 +143,9 @@ fn ignore() {
     ignore_typo_command.arg("--ignore").arg("RUSTSEC-2017-0003");
     assert_advisories(&mut ignore_typo_command, vec!["RUSTSEC-2017-0004"]);
 
-    assert_no_advisories(&mut (cargo_audit("no_vulns")
-        .arg("--ignore")
-        .arg("RUSTSEC-2017-0004")));
+    assert_no_advisories(
+        &mut (cargo_audit("no_vulns")
+            .arg("--ignore")
+            .arg("RUSTSEC-2017-0004")),
+    );
 }


### PR DESCRIPTION
- Updates `gumdrop` to v0.6
- Updates `rustsec` to v0.12 - requires Rust 1.32+