### PR TITLE
v0.7.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## [0.7.0] (2019-07-15)
+
+- Switch from `term` to `termcolor` crate ([#83])
+- Update `gumdrop` to v0.6, `rustsec` crate to v0.12; min Rust 1.32+ ([#82])
+- Produce valid JSON when no vulnerabilities are detected ([#77])
+- Implement `--ignore` option ([#75])
+
 ## [0.6.1] (2018-12-16)
 
 - Fix option parsing ([#64])
@@ -60,6 +67,11 @@
 
 - Initial release
 
+[0.7.0]: https://github.com/RustSec/cargo-audit/pull/84
+[#83]: https://github.com/RustSec/cargo-audit/pull/83
+[#82]: https://github.com/RustSec/cargo-audit/pull/82
+[#77]: https://github.com/RustSec/cargo-audit/pull/77
+[#75]: https://github.com/RustSec/cargo-audit/pull/75
 [0.6.1]: https://github.com/RustSec/cargo-audit/pull/65
 [#64]: https://github.com/RustSec/cargo-audit/pull/64
 [0.6.0]: https://github.com/RustSec/cargo-audit/pull/62

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-audit"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "assert_cmd 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gumdrop 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "cargo-audit"
 description = "Audit Cargo.lock for crates with security vulnerabilities"
-version     = "0.6.1"
+version     = "0.7.0"
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"
@@ -24,6 +24,6 @@ serde_json = "1"
 
 [dev-dependencies]
 assert_cmd = "0.11"
-serial_test = "*"
-serial_test_derive = "*"
+serial_test = "0.2"
+serial_test_derive = "0.2"
 tempfile = "3.0.8"


### PR DESCRIPTION
- Switch from `term` to `termcolor` crate (#83)
- Update `gumdrop` to v0.6, `rustsec` crate to v0.12; min Rust 1.32+ (#82)
- Produce valid JSON when no vulnerabilities are detected (#77)
- Implement `--ignore` option (#75)