### PR TITLE
Display dependency trees with each advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "gumdrop 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "home 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustsec 0.12.1 (git+https://github.com/rustsec/rustsec-crate)",
  "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -190,6 +191,11 @@ dependencies = [
  "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fnv"
@@ -375,9 +381,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordermap"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "petgraph"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "pkg-config"
@@ -798,6 +818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum darling_macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c6d8dac1c6f1d29a41c4712b4400f878cb4fcc4c7628f298dd75038e024998d1"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
+"checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum generational-arena 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4024f96ffa0ebaaf36aa589cd41f2fd69f3a5e6fd02c86e11e12cdf41d5b46a3"
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
@@ -820,7 +841,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.49 (registry+https://github.com/rust-lang/crates.io-index)" = "f4fad9e54bd23bd4cbbe48fdc08a1b8091707ac869ef8508edea2fec77dcc884"
+"checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+"checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
 "checksum pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c1d2cfa5a714db3b5f24f0915e74fcdf91d09d496ba61329705dda7774d2af"
 "checksum platforms 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6cfec0daac55b13af394ceaaad095d17c790f77bdc9329264f06e49d6cd3206c"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ failure = "0.1"
 gumdrop = "0.6"
 home = "0.5"
 lazy_static = "1"
+petgraph = "0.4"
 rustsec = "0.12"
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,3 +28,4 @@ pub mod commands;
 pub mod config;
 pub mod error;
 mod prelude;
+pub mod tree;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,0 +1,134 @@
+//! Support for displaying inverse dependency trees ala `cargo-tree -i`
+//!
+//! Bits and pieces taken from `cargo-tree`, Copyright (c) 2015-2016 Steven Fackler
+//! Licensed under the same terms as `cargo-audit` (i.e. Apache 2.0 + MIT)
+
+use petgraph::{
+    graph::{Graph, NodeIndex},
+    visit::EdgeRef,
+    EdgeDirection,
+};
+use rustsec::{package, Lockfile, Package};
+use std::collections::{BTreeMap as Map, BTreeSet as Set};
+
+/// Symbols which make up the tree
+struct Symbols {
+    down: &'static str,
+    tee: &'static str,
+    ell: &'static str,
+    right: &'static str,
+}
+
+/// UTF-8 representations of these symbols
+const UTF8_SYMBOLS: Symbols = Symbols {
+    down: "│",
+    tee: "├",
+    ell: "└",
+    right: "─",
+};
+
+/// Inverse dependency tree for a particular package
+// TODO(tarcieri): compute this once for the lockfile and reuse
+#[derive(Clone, Debug)]
+pub struct Tree {
+    /// Dependency graph for a particular package
+    graph: Graph<Package, Edge>,
+
+    /// Package data associated with nodes in the tree
+    nodes: Map<package::Name, NodeIndex>,
+
+    /// Root of the tree
+    root: NodeIndex,
+}
+
+impl Tree {
+    /// Construct a new tree for a particular package
+    pub fn new(lockfile: &Lockfile, package: &Package) -> Self {
+        let mut graph = Graph::new();
+        let root = graph.add_node(package.clone());
+
+        let mut nodes = Map::new();
+        nodes.insert(package.name.clone(), root);
+
+        let mut tree = Self { graph, nodes, root };
+        tree.add_dependent_packages(lockfile, package, root);
+        tree
+    }
+
+    /// Get the nodes of the tree
+    pub fn nodes(&self) -> &Map<package::Name, NodeIndex> {
+        &self.nodes
+    }
+
+    /// Print the tree to standard output
+    pub fn print(&self) {
+        let mut levels_continue = vec![];
+        let mut visited = Set::new();
+        self.print_node(self.root, &mut visited, &mut levels_continue);
+    }
+
+    /// Print a node in the dependency tree
+    fn print_node(
+        &self,
+        node: NodeIndex,
+        visited: &mut Set<package::Name>,
+        levels_continue: &mut Vec<bool>,
+    ) {
+        let package = &self.graph[node];
+        let new = visited.insert(package.name.clone());
+
+        if let Some((&last_continues, rest)) = levels_continue.split_last() {
+            for &continues in rest {
+                let c = if continues { UTF8_SYMBOLS.down } else { " " };
+                print!("{}   ", c);
+            }
+
+            let c = if last_continues {
+                UTF8_SYMBOLS.tee
+            } else {
+                UTF8_SYMBOLS.ell
+            };
+
+            print!("{0}{1}{1} ", c, UTF8_SYMBOLS.right);
+        }
+
+        println!("{} {}", &package.name, &package.version);
+
+        if !new {
+            return;
+        }
+
+        let dependencies = self
+            .graph
+            .edges_directed(node, EdgeDirection::Incoming)
+            .map(|edge| edge.source())
+            .collect::<Vec<_>>();
+
+        for (i, dependency) in dependencies.iter().enumerate() {
+            levels_continue.push(i < (dependencies.len() - 1));
+            self.print_node(*dependency, visited, levels_continue);
+            levels_continue.pop();
+        }
+    }
+
+    /// Add the dependencies of a given package to the given node
+    fn add_dependent_packages(
+        &mut self,
+        lockfile: &Lockfile,
+        package: &Package,
+        parent: NodeIndex,
+    ) {
+        for dependent_package in lockfile.dependent_packages(package) {
+            let node = self.graph.add_node(dependent_package.clone());
+            self.nodes.insert(dependent_package.name.clone(), node);
+
+            self.graph.add_edge(node, parent, Edge);
+            self.add_dependent_packages(lockfile, dependent_package, node);
+        }
+    }
+}
+
+/// Graph edges. These are presently just a placeholder.
+// TODO(tarcieri): use these for e.g. VersionReqs?
+#[derive(Clone, Debug)]
+pub struct Edge;


### PR DESCRIPTION
Shows a complete tree of dependencies associated with each vulnerable package in the lockfile.

This is useful for determining how vulnerable packages are being pulled into the project.

<img width="709" alt="Screen Shot 2019-09-08 at 10 51 23 AM" src="https://user-images.githubusercontent.com/797/64492286-43872a80-d227-11e9-9ef3-1bb78cb7b789.png">
