### PR TITLE
Warn for outdated `rustsec` crate versions

### DIFF
--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -261,6 +261,20 @@ impl AuditCommand {
                 })
         };
 
+        if let Ok(support_info) = advisory_db_repo.support() {
+            if let Some(rustsec_update) = support_info.rustsec.next_update {
+                if !rustsec_update
+                    .version
+                    .matches(&rustsec::VERSION.parse().unwrap())
+                {
+                    status_warn!(
+                        "support for this version of `cargo-audit` ends on {}. Please upgrade!",
+                        rustsec_update.date.as_str()
+                    );
+                }
+            }
+        }
+
         let advisory_db = rustsec::Database::load(&advisory_db_repo).unwrap_or_else(|e| {
             status_err!("error loading advisory database: {}", e);
             exit(1);


### PR DESCRIPTION
Checks the included `rustsec` crate version against signaling coming from the Advisory DB itself to determine if an obsolete version of `cargo-audit` is in use.