### PR TITLE
Extract `Auditor` and populate `AuditConfig`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,7 @@ dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ keywords    = ["cargo-subcommand", "security", "audit", "vulnerability"]
 edition     = "2018"
 
 [badges]
-travis-ci = { repository = "rustsec/cargo-audit" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
@@ -28,6 +27,7 @@ serde_json = "1"
 
 [dev-dependencies]
 tempfile = "3"
+toml = "0.5"
 
 [dev-dependencies.abscissa_core]
 version = "0.3"

--- a/audit.toml.example
+++ b/audit.toml.example
@@ -1,0 +1,31 @@
+# Example `~/.cargo/audit.toml` file
+# All of the options which can be passed via CLI arguments can also be
+# permanently specified in this file.
+
+# Path where the advisory database's git repo will be cloned to
+advisory_db_path = "~/.cargo/advisory-db"
+
+# URL to the advisory database's git repository
+advisory_db_url = "https://github.com/RustSec/advisory-db.git"
+
+# Ignore advisory database which hasn't been updated in over 90 days
+allow_stale = false
+
+# When should colors be displayed? ("always", "never", or "auto")
+color = "auto"
+
+# List of advisory IDs to ignore e.g. ["RUSTSEC-2019-0001", "RUSTSEC-2019-0002"]
+ignore = []
+
+# Don't automatically fetch the advisory DB via git
+no_fetch = false
+
+# Output format ("terminal" or "json")
+output_format = "terminal"
+
+# Operate quielty only printing out information on error
+quiet = false
+
+# Severity threshold to alert at on the CVSS Qualitative Severity Rating Scale.
+# Valid options are: "none", "low", "medium", "high", "critical"
+severity_threshold = "low"

--- a/src/application.rs
+++ b/src/application.rs
@@ -2,7 +2,7 @@
 //!
 //! <https://docs.rs/abscissa_core>
 
-use crate::{commands::CargoAuditCommand, config::CargoAuditConfig};
+use crate::{commands::CargoAuditCommand, config::AuditConfig};
 use abscissa_core::{
     application, config, logging, Application, EntryPoint, FrameworkError, StandardPaths,
 };
@@ -36,7 +36,7 @@ pub fn app_config() -> config::Reader<CargoAuditApplication> {
 #[derive(Debug)]
 pub struct CargoAuditApplication {
     /// Application configuration.
-    config: Option<CargoAuditConfig>,
+    config: Option<AuditConfig>,
 
     /// Application state.
     state: application::State<Self>,
@@ -60,13 +60,13 @@ impl Application for CargoAuditApplication {
     type Cmd = EntryPoint<CargoAuditCommand>;
 
     /// Application configuration.
-    type Cfg = CargoAuditConfig;
+    type Cfg = AuditConfig;
 
     /// Paths to resources within the application.
     type Paths = StandardPaths;
 
     /// Accessor for application configuration.
-    fn config(&self) -> &CargoAuditConfig {
+    fn config(&self) -> &AuditConfig {
         self.config.as_ref().expect("config not loaded")
     }
 

--- a/src/auditor.rs
+++ b/src/auditor.rs
@@ -1,0 +1,254 @@
+//! Core auditing functionality
+
+use crate::{
+    config::{AuditConfig, OutputFormat},
+    error::{Error, ErrorKind},
+    tree::Tree,
+};
+use abscissa_core::terminal::{
+    self,
+    Color::{Red, Yellow},
+};
+use rustsec::{lockfile::Lockfile, report, Vulnerability};
+use std::{
+    collections::BTreeSet as Set,
+    io::{self, Read},
+    path::Path,
+    process::exit,
+};
+
+/// Security vulnerability auditor
+pub struct Auditor {
+    /// RustSec Advisory Database
+    database: rustsec::Database,
+
+    /// Output format to display
+    output_format: OutputFormat,
+
+    /// Are we operating in quiet mode?
+    quiet: bool,
+
+    /// Report settings to use when generating audit report
+    report_settings: report::Settings,
+}
+
+impl Auditor {
+    /// Initialize the auditor
+    pub fn new(config: &AuditConfig) -> Self {
+        // Use quiet mode if explicitly configured or if we're outputting JSON
+        let quiet = config.quiet || config.output_format == OutputFormat::Json;
+
+        let advisory_db_url = config
+            .advisory_db_url
+            .as_ref()
+            .map(AsRef::as_ref)
+            .unwrap_or(rustsec::DEFAULT_REPO_URL);
+
+        let advisory_db_path = config
+            .advisory_db_path
+            .as_ref()
+            .cloned()
+            .unwrap_or_else(rustsec::Repository::default_path);
+
+        let advisory_db_repo = if config.no_fetch {
+            rustsec::Repository::open(&advisory_db_path).unwrap_or_else(|e| {
+                status_err!("couldn't open advisory database: {}", e);
+                exit(1);
+            })
+        } else {
+            if !quiet {
+                status_ok!("Fetching", "advisory database from `{}`", advisory_db_url);
+            }
+
+            rustsec::Repository::fetch(advisory_db_url, &advisory_db_path, !config.allow_stale)
+                .unwrap_or_else(|e| {
+                    status_err!("couldn't fetch advisory database: {}", e);
+                    exit(1);
+                })
+        };
+
+        if let Ok(support_info) = advisory_db_repo.support() {
+            if let Some(rustsec_update) = support_info.rustsec.next_update {
+                if !rustsec_update
+                    .version
+                    .matches(&rustsec::VERSION.parse().unwrap())
+                {
+                    status_warn!(
+                        "support for this version of `cargo-audit` ends on {}. Please upgrade!",
+                        rustsec_update.date.as_str()
+                    );
+                }
+            }
+        }
+
+        let database = rustsec::Database::load(&advisory_db_repo).unwrap_or_else(|e| {
+            status_err!("error loading advisory database: {}", e);
+            exit(1);
+        });
+
+        if !quiet {
+            status_ok!(
+                "Loaded",
+                "{} security advisories (from {})",
+                database.iter().count(),
+                advisory_db_path.display()
+            );
+        }
+
+        Self {
+            database,
+            output_format: config.output_format,
+            quiet,
+            report_settings: config.report_settings(),
+        }
+    }
+
+    /// Perform audit
+    pub fn audit(&self, lockfile_path: &Path) {
+        let lockfile = self
+            .load_lockfile(lockfile_path)
+            .unwrap_or_else(|e| match e.kind() {
+                ErrorKind::Io => {
+                    status_err!("Couldn't find '{}'!", lockfile_path.display());
+                    println!(
+                    "\nRun \"cargo generate-lockfile\" to generate lockfile before running audit"
+                );
+                    exit(1);
+                }
+                _ => {
+                    status_err!("Couldn't load {}: {}", lockfile_path.display(), e);
+                    exit(1);
+                }
+            });
+
+        if !self.quiet {
+            status_ok!(
+                "Scanning",
+                "{} for vulnerabilities ({} crate dependencies)",
+                lockfile_path.display(),
+                lockfile.packages.len(),
+            );
+        }
+
+        let report = rustsec::Report::generate(&self.database, &lockfile, &self.report_settings);
+
+        if !self.quiet {
+            if report.vulnerabilities.found {
+                status_err!("Vulnerable crates found!");
+            } else {
+                status_ok!("Success", "No vulnerable packages found");
+            }
+        }
+
+        match self.output_format {
+            OutputFormat::Json => serde_json::to_writer(io::stdout(), &report).unwrap(),
+            OutputFormat::Terminal => {
+                // Track packages we've displayed once so we don't show the same dep tree
+                // TODO(tarcieri): group advisories about the same package?
+                let mut displayed_packages = Set::new();
+
+                for vulnerability in &report.vulnerabilities.list {
+                    if displayed_packages.insert(vulnerability.package.name.clone()) {
+                        let tree = Tree::new(&lockfile);
+                        display_vulnerability(&vulnerability, Some(&tree));
+                    } else {
+                        display_vulnerability(&vulnerability, None);
+                    }
+                }
+
+                if !report.warnings.is_empty() {
+                    println!();
+
+                    status_warn!("found informational advisories for dependencies");
+
+                    for warning in &report.warnings {
+                        println!();
+
+                        display_attr(Yellow, "Crate:   ", warning.package.as_str());
+                        display_attr(Red, "Message: ", warning.message.as_str());
+
+                        if let Some(url) = &warning.url {
+                            display_attr(Yellow, "URL:     ", url);
+                        }
+                    }
+                }
+            }
+        }
+
+        if report.vulnerabilities.found {
+            println!();
+
+            if report.vulnerabilities.count == 1 {
+                status_err!("1 vulnerability found!");
+            } else {
+                status_err!("{} vulnerabilities found!", report.vulnerabilities.count);
+            }
+
+            exit(1);
+        }
+    }
+
+    /// Load the lockfile to be audited
+    fn load_lockfile(&self, lockfile_path: &Path) -> Result<Lockfile, Error> {
+        if lockfile_path == Path::new("-") {
+            // Read Cargo.lock from STDIN
+            let mut lockfile_toml = String::new();
+            io::stdin().read_to_string(&mut lockfile_toml)?;
+            Ok(lockfile_toml.parse()?)
+        } else {
+            Ok(Lockfile::load(lockfile_path)?)
+        }
+    }
+}
+
+/// Display information about a particular vulnerability
+fn display_vulnerability(vulnerability: &Vulnerability, tree: Option<&Tree>) {
+    let advisory = &vulnerability.advisory;
+
+    println!();
+    display_attr(Red, "ID:      ", advisory.id.as_str());
+    display_attr(Red, "Crate:   ", vulnerability.package.name.as_str());
+    display_attr(Red, "Version: ", &vulnerability.package.version.to_string());
+    display_attr(Red, "Date:    ", advisory.date.as_str());
+
+    if let Some(url) = advisory.id.url() {
+        display_attr(Red, "URL:     ", &url);
+    } else if let Some(url) = advisory.url.as_ref() {
+        display_attr(Red, "URL:     ", url);
+    }
+
+    display_attr(Red, "Title:   ", &advisory.title);
+    display_attr(
+        Red,
+        "Solution: upgrade to",
+        &vulnerability
+            .versions
+            .patched
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .as_slice()
+            .join(" OR "),
+    );
+
+    if let Some(t) = tree {
+        terminal::status::Status::new()
+            .bold()
+            .color(Red)
+            .status("Dependency tree:")
+            .print_stdout("")
+            .unwrap();
+
+        t.print(&vulnerability.package);
+    }
+}
+
+/// Display an attribute of a particular vulnerability
+fn display_attr(color: terminal::Color, attr: &str, content: &str) {
+    terminal::status::Status::new()
+        .bold()
+        .color(color)
+        .status(attr)
+        .print_stdout(content)
+        .unwrap();
+}

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -3,7 +3,7 @@
 mod audit;
 
 use self::audit::AuditCommand;
-use crate::config::CargoAuditConfig;
+use crate::config::AuditConfig;
 use abscissa_core::{config::Override, Command, Configurable, FrameworkError, Options, Runnable};
 use std::path::PathBuf;
 
@@ -20,7 +20,7 @@ pub enum CargoAuditCommand {
     Audit(AuditCommand),
 }
 
-impl Configurable<CargoAuditConfig> for CargoAuditCommand {
+impl Configurable<AuditConfig> for CargoAuditCommand {
     /// Location of `audit.toml` (if it exists)
     fn config_path(&self) -> Option<PathBuf> {
         // Check if the config file exists, and if it does not, ignore it.
@@ -36,7 +36,7 @@ impl Configurable<CargoAuditConfig> for CargoAuditCommand {
     }
 
     /// Override loaded config with explicit command-line arguments
-    fn process_config(&self, config: CargoAuditConfig) -> Result<CargoAuditConfig, FrameworkError> {
+    fn process_config(&self, config: AuditConfig) -> Result<AuditConfig, FrameworkError> {
         match self {
             CargoAuditCommand::Audit(cmd) => cmd.override_config(config),
         }

--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -2,31 +2,14 @@
 
 use super::CargoAuditCommand;
 use crate::{
-    config::CargoAuditConfig,
-    error::{Error, ErrorKind},
-    tree::Tree,
+    auditor::Auditor,
+    config::{AuditConfig, OutputFormat},
+    prelude::*,
 };
-use abscissa_core::{
-    config::Override,
-    terminal::{
-        self,
-        Color::{Red, Yellow},
-    },
-    Command, FrameworkError, Runnable,
-};
+use abscissa_core::{config::Override, FrameworkError};
 use gumdrop::Options;
-use rustsec::{
-    advisory,
-    lockfile::Lockfile,
-    platforms::target::{Arch, OS},
-    report, Vulnerability,
-};
-use std::{
-    collections::BTreeSet as Set,
-    io::{self, Read},
-    path::{Path, PathBuf},
-    process::exit,
-};
+use rustsec::platforms::target::{Arch, OS};
+use std::{path::PathBuf, process::exit};
 
 /// Name of `Cargo.lock`
 const CARGO_LOCK_FILE: &str = "Cargo.lock";
@@ -65,6 +48,15 @@ pub struct AuditCommand {
         help = "Cargo lockfile to inspect (or `-` for STDIN, default: Cargo.lock)"
     )]
     file: Option<String>,
+
+    /// Advisory ids to ignore
+    #[options(
+        no_short,
+        long = "ignore",
+        meta = "ADVISORY_ID",
+        help = "Advisory id to ignore (can be specified multiple times)"
+    )]
+    ignore: Vec<String>,
 
     /// Skip fetching the advisory database git repository
     #[options(
@@ -109,24 +101,45 @@ pub struct AuditCommand {
     /// Output reports as JSON
     #[options(no_short, long = "json", help = "Output report in JSON format")]
     output_json: bool,
-
-    /// Advisory ids to ignore
-    #[options(
-        no_short,
-        long = "ignore",
-        meta = "ADVISORY_ID",
-        help = "Advisory id to ignore (can be specified multiple times)"
-    )]
-    ignore: Vec<String>,
 }
 
-impl Override<CargoAuditConfig> for AuditCommand {
-    fn override_config(
-        &self,
-        mut config: CargoAuditConfig,
-    ) -> Result<CargoAuditConfig, FrameworkError> {
+impl Override<AuditConfig> for AuditCommand {
+    fn override_config(&self, mut config: AuditConfig) -> Result<AuditConfig, FrameworkError> {
         if let Some(color) = &self.color {
-            config.display.color = Some(color.clone());
+            config.color = Some(color.clone());
+        }
+
+        if let Some(db) = &self.db {
+            config.advisory_db_path = Some(db.into());
+        }
+
+        for advisory_id in &self.ignore {
+            // TODO(tarcieri): handle/ignore duplicate advisory IDs between config and CLI opts
+            config.ignore.push(advisory_id.parse().unwrap_or_else(|e| {
+                status_err!("error parsing {}: {}", advisory_id, e);
+                exit(1);
+            }));
+        }
+
+        config.no_fetch |= self.no_fetch;
+        config.allow_stale |= self.stale;
+
+        if let Some(target_arch) = self.target_arch {
+            config.target_arch = Some(target_arch);
+        }
+
+        if let Some(target_os) = self.target_os {
+            config.target_os = Some(target_os);
+        }
+
+        if let Some(url) = &self.url {
+            config.advisory_db_url = Some(url.clone())
+        }
+
+        config.quiet |= self.quiet;
+
+        if self.output_json {
+            config.output_format = OutputFormat::Json;
         }
 
         Ok(config)
@@ -140,257 +153,24 @@ impl Runnable for AuditCommand {
         }
 
         if self.version {
-            println!(
-                "{} {}",
-                CargoAuditCommand::name(),
-                CargoAuditCommand::version()
-            );
+            println!("cargo-audit {}", CargoAuditCommand::version());
             exit(0);
         }
 
-        let lockfile = self.load_lockfile().unwrap_or_else(|e| match e.kind() {
-            ErrorKind::Io => {
-                status_err!("Couldn't find '{}'!", self.lockfile_path().display());
-                println!(
-                    "\nRun \"cargo generate-lockfile\" to generate lockfile before running audit"
-                );
-                exit(1);
-            }
-            _ => {
-                status_err!("Couldn't load {}: {}", self.lockfile_path().display(), e);
-                exit(1);
-            }
-        });
+        let lockfile_path = self
+            .file
+            .as_ref()
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(CARGO_LOCK_FILE));
 
-        let advisory_db = self.load_advisory_db();
-
-        if !self.quiet() {
-            status_ok!(
-                "Scanning",
-                "{} for vulnerabilities ({} crate dependencies)",
-                self.lockfile_path().display(),
-                lockfile.packages.len(),
-            );
-        }
-
-        let report = rustsec::Report::generate(&advisory_db, &lockfile, &self.report_settings());
-
-        if !self.quiet() {
-            if report.vulnerabilities.found {
-                status_err!("Vulnerable crates found!");
-            } else {
-                status_ok!("Success", "No vulnerable packages found");
-            }
-        }
-
-        if self.output_json {
-            serde_json::to_writer(io::stdout(), &report).unwrap();
-        } else {
-            // Track packages we've displayed once so we don't show the same dep tree
-            // TODO(tarcieri): group advisories about the same package?
-            let mut displayed_packages = Set::new();
-
-            for vulnerability in &report.vulnerabilities.list {
-                if displayed_packages.insert(vulnerability.package.name.clone()) {
-                    let tree = Tree::new(&lockfile);
-                    display_vulnerability(&vulnerability, Some(&tree));
-                } else {
-                    display_vulnerability(&vulnerability, None);
-                }
-            }
-
-            if !report.warnings.is_empty() {
-                println!();
-
-                status_warn!("found informational advisories for dependencies");
-
-                for warning in &report.warnings {
-                    println!();
-
-                    display_attr(Yellow, "Crate:   ", warning.package.as_str());
-                    display_attr(Red, "Message: ", warning.message.as_str());
-
-                    if let Some(url) = &warning.url {
-                        display_attr(Yellow, "URL:     ", url);
-                    }
-                }
-            }
-        }
-
-        if report.vulnerabilities.found {
-            println!();
-
-            if report.vulnerabilities.count == 1 {
-                status_err!("1 vulnerability found!");
-            } else {
-                status_err!("{} vulnerabilities found!", report.vulnerabilities.count);
-            }
-
-            exit(1);
-        } else {
-            exit(0);
-        }
+        self.auditor().audit(&lockfile_path);
     }
 }
 
 impl AuditCommand {
-    /// Should we suppress excessive output?
-    fn quiet(&self) -> bool {
-        self.quiet || self.output_json
+    /// Initialize `Auditor`
+    pub fn auditor(&self) -> Auditor {
+        let config = app_config();
+        Auditor::new(&config)
     }
-
-    /// Load the advisory database
-    fn load_advisory_db(&self) -> rustsec::Database {
-        let advisory_repo_url = self
-            .url
-            .as_ref()
-            .map(AsRef::as_ref)
-            .unwrap_or(rustsec::DEFAULT_REPO_URL);
-
-        let advisory_repo_path = self
-            .db
-            .as_ref()
-            .map(PathBuf::from)
-            .unwrap_or_else(rustsec::Repository::default_path);
-
-        let advisory_db_repo = if self.no_fetch {
-            rustsec::Repository::open(&advisory_repo_path).unwrap_or_else(|e| {
-                status_err!("couldn't open advisory database: {}", e);
-                exit(1);
-            })
-        } else {
-            if !self.quiet() {
-                status_ok!("Fetching", "advisory database from `{}`", advisory_repo_url);
-            }
-
-            rustsec::Repository::fetch(advisory_repo_url, &advisory_repo_path, !self.stale)
-                .unwrap_or_else(|e| {
-                    status_err!("couldn't fetch advisory database: {}", e);
-                    exit(1);
-                })
-        };
-
-        if let Ok(support_info) = advisory_db_repo.support() {
-            if let Some(rustsec_update) = support_info.rustsec.next_update {
-                if !rustsec_update
-                    .version
-                    .matches(&rustsec::VERSION.parse().unwrap())
-                {
-                    status_warn!(
-                        "support for this version of `cargo-audit` ends on {}. Please upgrade!",
-                        rustsec_update.date.as_str()
-                    );
-                }
-            }
-        }
-
-        let advisory_db = rustsec::Database::load(&advisory_db_repo).unwrap_or_else(|e| {
-            status_err!("error loading advisory database: {}", e);
-            exit(1);
-        });
-
-        if !self.quiet() {
-            status_ok!(
-                "Loaded",
-                "{} security advisories (from {})",
-                advisory_db.iter().count(),
-                advisory_repo_path.display()
-            );
-        }
-
-        advisory_db
-    }
-
-    /// Get the path to the lockfile
-    fn lockfile_path(&self) -> PathBuf {
-        self.file
-            .as_ref()
-            .map(PathBuf::from)
-            .unwrap_or_else(|| PathBuf::from(CARGO_LOCK_FILE))
-    }
-
-    /// Load the lockfile to be audited
-    fn load_lockfile(&self) -> Result<Lockfile, Error> {
-        let path = self.lockfile_path();
-
-        if path.as_path() == Path::new("-") {
-            // Read Cargo.lock from STDIN
-            let mut lockfile_toml = String::new();
-            io::stdin().read_to_string(&mut lockfile_toml)?;
-            Ok(lockfile_toml.parse()?)
-        } else {
-            Ok(Lockfile::load(path)?)
-        }
-    }
-
-    /// Get the report settings to use
-    fn report_settings(&self) -> report::Settings {
-        let mut settings = rustsec::report::Settings::default();
-        settings.target_arch = self.target_arch;
-        settings.target_os = self.target_os;
-        settings.severity = Some(advisory::Severity::Low);
-        settings.informational_warnings = vec![advisory::Informational::Unmaintained];
-        settings.ignore = self
-            .ignore
-            .iter()
-            .map(|id| {
-                id.parse().unwrap_or_else(|e| {
-                    status_err!("error parsing {}: {}", id, e);
-                    exit(1);
-                })
-            })
-            .collect();
-
-        settings
-    }
-}
-
-/// Display information about a particular vulnerability
-fn display_vulnerability(vulnerability: &Vulnerability, tree: Option<&Tree>) {
-    let advisory = &vulnerability.advisory;
-
-    println!();
-    display_attr(Red, "ID:      ", advisory.id.as_str());
-    display_attr(Red, "Crate:   ", vulnerability.package.name.as_str());
-    display_attr(Red, "Version: ", &vulnerability.package.version.to_string());
-    display_attr(Red, "Date:    ", advisory.date.as_str());
-
-    if let Some(url) = advisory.url.as_ref() {
-        display_attr(Red, "URL:     ", url);
-    }
-
-    display_attr(Red, "Title:   ", &advisory.title);
-    display_attr(
-        Red,
-        "Solution: upgrade to",
-        &vulnerability
-            .versions
-            .patched
-            .iter()
-            .map(ToString::to_string)
-            .collect::<Vec<_>>()
-            .as_slice()
-            .join(" OR "),
-    );
-
-    if let Some(t) = tree {
-        terminal::status::Status::new()
-            .bold()
-            .color(Red)
-            .status("Dependency tree:")
-            .print_stdout("")
-            .unwrap();
-
-        t.print(&vulnerability.package);
-    }
-}
-
-/// Display an attribute of a particular vulnerability
-fn display_attr(color: terminal::Color, attr: &str, content: &str) {
-    terminal::status::Status::new()
-        .bold()
-        .color(color)
-        .status(attr)
-        .print_stdout(content)
-        .unwrap();
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,30 +1,86 @@
 //! The `~/.cargo/audit.toml` configuration file
 
 use abscissa_core::Config;
+use rustsec::{
+    advisory,
+    platforms::target::{Arch, OS},
+    report,
+};
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 /// `cargo audit` configuration:
 ///
 /// An optional TOML config file located in `~/.cargo/audit.toml`
 #[derive(Clone, Config, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct CargoAuditConfig {
-    /// An example configuration section
-    pub display: DisplayConfig,
-}
+pub struct AuditConfig {
+    /// Path to the advisory database's git repo
+    pub advisory_db_path: Option<PathBuf>,
 
-/// Options for how audit reports are displayed
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct DisplayConfig {
-    /// Should we display colors?
+    /// URL to the advisory database
+    pub advisory_db_url: Option<String>,
+
+    /// Allow a stale advisory database?
+    pub allow_stale: bool,
+
+    /// Should colors be displayed?
     pub color: Option<String>,
+
+    /// Vector of advisories to be ignored
+    #[serde(default)]
+    pub ignore: Vec<advisory::Id>,
+
+    /// Should we skip fetching the advisory database from git?
+    pub no_fetch: bool,
+
+    /// Output format to use
+    #[serde(default)]
+    pub output_format: OutputFormat,
+
+    /// Enable quiet mode
+    pub quiet: bool,
+
+    /// Ignore advisories with a severity lower than this threshold
+    pub severity_threshold: Option<advisory::Severity>,
+
+    /// Target architecture to find vulnerabilities for
+    pub target_arch: Option<Arch>,
+
+    /// Target OS to find vulnerabilities for
+    pub target_os: Option<OS>,
 }
 
-impl Default for DisplayConfig {
+impl AuditConfig {
+    /// Get audit report settings from the configuration
+    pub fn report_settings(&self) -> report::Settings {
+        let mut settings = rustsec::report::Settings::default();
+
+        // TODO(tarcieri): support for customizing informational advisory types to warn for
+        settings.informational_warnings = vec![advisory::Informational::Unmaintained];
+        settings.ignore = self.ignore.clone();
+        settings.severity = self.severity_threshold;
+        settings.target_arch = self.target_arch;
+        settings.target_os = self.target_os;
+
+        settings
+    }
+}
+
+/// Output format
+#[derive(Copy, Clone, Config, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum OutputFormat {
+    /// Display JSON
+    #[serde(rename = "json")]
+    Json,
+
+    /// Display human-readable output to the terminal
+    #[serde(rename = "terminal")]
+    Terminal,
+}
+
+impl Default for OutputFormat {
     fn default() -> Self {
-        Self {
-            color: Some("auto".to_owned()),
-        }
+        OutputFormat::Terminal
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@
 extern crate abscissa_core;
 
 pub mod application;
+pub mod auditor;
 pub mod commands;
 pub mod config;
 pub mod error;

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,0 +1,20 @@
+//! Configuration file tests
+
+use cargo_audit::config::AuditConfig;
+use std::{fs, path::Path};
+
+/// Ensure `audit.toml.example` parses as a valid config file
+#[test]
+fn parse_audit_toml_example() {
+    let toml_string = fs::read_to_string("audit.toml.example").unwrap();
+    let config: AuditConfig = toml::from_str(&toml_string).unwrap();
+
+    assert_eq!(
+        config.advisory_db_path.unwrap(),
+        Path::new("~/.cargo/advisory-db")
+    );
+    assert_eq!(
+        config.advisory_db_url.unwrap(),
+        "https://github.com/RustSec/advisory-db.git"
+    );
+}


### PR DESCRIPTION
Extracts the core functionality from `AuditCommand` into a new `Auditor` type which deals with performing the audit.

Additionally moves all auditing options into `AuditConfig` and uses Abscissa's `config::Override` to populate them from command-line arguments.