### PR TITLE
v0.9.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+## [0.9.0] (2019-09-25)
+
+- Add `--deny-warnings` option ([#128])
+- Upgrade to `rustsec` crate v0.14 ([#126])
+- Configuration file: `~/.cargo/audit.toml` ([#123], [#125])
+- Fix `--help` ([#113])
+- Warn for outdated `rustsec` crate versions ([#112])
+- Display warnings for select informational advisories ([#110])
+- Display dependency trees with each advisory ([#109])
+
 ## [0.8.1] (2019-08-25)
 
 - Fix `--version` ([#101])
@@ -77,6 +87,15 @@
 
 - Initial release
 
+[0.9.0]: https://github.com/RustSec/cargo-audit/pull/130
+[#128]: https://github.com/RustSec/cargo-audit/pull/128
+[#126]: https://github.com/RustSec/cargo-audit/pull/126
+[#125]: https://github.com/RustSec/cargo-audit/pull/125
+[#123]: https://github.com/RustSec/cargo-audit/pull/123
+[#113]: https://github.com/RustSec/cargo-audit/pull/113
+[#112]: https://github.com/RustSec/cargo-audit/pull/112
+[#110]: https://github.com/RustSec/cargo-audit/pull/110
+[#109]: https://github.com/RustSec/cargo-audit/pull/109
 [0.8.1]: https://github.com/RustSec/cargo-audit/pull/102
 [#101]: https://github.com/RustSec/cargo-audit/pull/101
 [0.8.0]: https://github.com/RustSec/cargo-audit/pull/99

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cargo-audit"
-version = "0.9.0-beta2"
+version = "0.9.0"
 dependencies = [
  "abscissa_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "cargo-audit"
 description = "Audit Cargo.lock for crates with security vulnerabilities"
-version     = "0.9.0-beta2"
+version     = "0.9.0"
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/master/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/cargo-audit/0.9.0-beta2"
+    html_root_url = "https://docs.rs/cargo-audit/0.9.0"
 )]
 
 pub mod application;


### PR DESCRIPTION
- Add `--deny-warnings` option (#128)
- Upgrade to `rustsec` crate v0.14 (#126)
- Configuration file: `~/.cargo/audit.toml` (#123, #125)
- Fix `--help` (#113)
- Warn for outdated `rustsec` crate versions (#112)
- Display warnings for select informational advisories (#110)
- Display dependency trees with each advisory (#109)