### PR TITLE
Print the fact that no solution is available

### DIFF
--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -133,18 +133,27 @@ impl Presenter {
         }
 
         self.print_attr(Red, "Title:   ", &advisory.title);
-        self.print_attr(
-            Red,
-            "Solution: upgrade to",
-            &vulnerability
-                .versions
-                .patched
-                .iter()
-                .map(ToString::to_string)
-                .collect::<Vec<_>>()
-                .as_slice()
-                .join(" OR "),
-        );
+        if vulnerability.versions.patched.is_empty() {
+            self.print_attr(
+                Red,
+                "Solution:",
+                String::from(" No safe upgrade is available!"),
+            );
+        } else {
+            self.print_attr(
+                Red,
+                "Solution:",
+                String::from(" upgrade to ")
+                    + &vulnerability
+                        .versions
+                        .patched
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .as_slice()
+                        .join(" OR "),
+            );
+        }
 
         self.print_tree(Red, &vulnerability.package, tree);
     }


### PR DESCRIPTION
Previously, if no solution is available, it will simplyprint `Solution: upgrade to <<nothing>>`.
This commit changes that and will mention the fact that no advisable upgrade is available...