### PR TITLE
Upgrade to rustsec v0.15.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ dependencies = [
  "home 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustsec 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustsec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -556,7 +556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustsec"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cargo-lock 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -898,7 +898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
-"checksum rustsec 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fec9901c8db7648a9a619926a7515b070838042419f93bd1e443d286efd844a"
+"checksum rustsec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "016d6cdd552d040a73cfb20ee12ce4a39ce1a8c04c4a9a8bfd93cb9f21756f86"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum secrecy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "69381774972c1fe76bfd9001609fa2b6f97674a1cb6e43bd51d6e9d7d26880c9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ gumdrop = "0.6"
 home = "0.5"
 lazy_static = "1"
 petgraph = "0.4"
-rustsec = { version = "0.15", features = ["dependency-tree"] }
+rustsec = { version = "0.15.2", features = ["dependency-tree"] }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 


### PR DESCRIPTION
This version contains an important bugfix, so it will be nice to know that the next release of cargo-audit always contains it.

https://github.com/RustSec/rustsec-crate/pull/122