### PR TITLE
v0.9.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## [0.9.3] (2019-10-08)
+
+- Update to `rustsec` crate v0.15.2 ([#149])
+- presenter: Cleanups for informational advisories ([#148])
+- presenter: Print better message when no solution is available ([#144])
+
 ## [0.9.2] (2019-10-01)
 
 - Update to `rustsec` crate v0.15 ([#138])
@@ -95,6 +101,10 @@
 
 - Initial release
 
+[0.9.3]: https://github.com/RustSec/cargo-audit/pull/150
+[#149]: https://github.com/RustSec/cargo-audit/pull/149
+[#148]: https://github.com/RustSec/cargo-audit/pull/148
+[#144]: https://github.com/RustSec/cargo-audit/pull/144
 [0.9.2]: https://github.com/RustSec/cargo-audit/pull/139
 [#138]: https://github.com/RustSec/cargo-audit/pull/138
 [0.9.1]: https://github.com/RustSec/cargo-audit/pull/135

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cargo-audit"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "abscissa_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "cargo-audit"
 description = "Audit Cargo.lock for crates with security vulnerabilities"
-version     = "0.9.2"
+version     = "0.9.3"
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/master/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/cargo-audit/0.9.2"
+    html_root_url = "https://docs.rs/cargo-audit/0.9.3"
 )]
 
 pub mod application;


### PR DESCRIPTION
- Update to `rustsec` crate v0.15.2 (#149)
- presenter: Cleanups for informational advisories (#148)
- presenter: Print better message when no solution is available (#144)