### PR TITLE
Implement --fix option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,8 @@ petgraph = "0.4"
 rustsec = { version = "0.15.2", features = ["dependency-tree"] }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
-cargo-edit = { git = "https://github.com/killercup/cargo-edit#cargo-upgrade" }
+cargo-edit = { git = "https://github.com/killercup/cargo-edit.git" }
+
 [dev-dependencies]
 tempfile = "3"
 toml = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ petgraph = "0.4"
 rustsec = { version = "0.15.2", features = ["dependency-tree"] }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
-
+cargo-edit = { git = "https://github.com/killercup/cargo-edit#cargo-upgrade" }
 [dev-dependencies]
 tempfile = "3"
 toml = "0.5"

--- a/src/auditor.rs
+++ b/src/auditor.rs
@@ -93,7 +93,7 @@ impl Auditor {
     }
 
     /// Perform audit
-    pub fn audit(&mut self, maybe_lockfile_path: Option<&Path>) -> rustsec::Report {
+    pub fn audit(&mut self, maybe_lockfile_path: &Option<&Path>) -> rustsec::Report {
         let lockfile_path = maybe_lockfile_path.unwrap_or_else(|| {
             let path = Path::new(CARGO_LOCK_FILE);
 

--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -192,14 +192,18 @@ impl Runnable for AuditCommand {
                 .list
                 .iter()
                 .for_each(|vulnerability| {
-                    manifest
-                        .upgrade(
-                            &Dependency::new(vulnerability.package.name.as_str()).set_version(
-                                vulnerability.versions.patched[0].to_string().as_str(),
-                            ),
-                            false,
-                        )
-                        .expect("unable to perform upgrade.");
+                    if vulnerability.versions.patched.is_empty() {
+                        println!("no upgrade available for {}", vulnerability.package.name);
+                    } else {
+                        manifest
+                            .upgrade(
+                                &Dependency::new(vulnerability.package.name.as_str()).set_version(
+                                    vulnerability.versions.patched[0].to_string().as_str(), // this does not look good at all...
+                                ),
+                                false,
+                            )
+                            .expect("unable to perform upgrade.");
+                    }
                 });
         }
         if report.vulnerabilities.found {


### PR DESCRIPTION
This option allows the program to automatically perform the recommended (if available) upgrade for the user.

Resolves #23 

Not entirely sure if the code is within reasonable idiomatic `Rust` standard.

Since, I am using `cargo-edit` for this, the way I did it is a lot simpler that what was suggested [here](https://github.com/RustSec/cargo-audit/issues/23#issuecomment-538666084). So I am not entirely sure if my PR is correct or is aligned with what @tarcieri had in mind.

I think there are niche cases that I am not handling (what happen if there is no upgrade?). In particular, this is just clumsy code on my part,

`vulnerability.versions.patched[0].to_string().as_str(),`

The suggestions laid out in Zulip is to perform some arithmetic to figure out the suitable versions to upgrade to. But I find this an unnecessary work, and I must admit I am not entirely sure if I am capable of implementing them...not without some hand holding.

Edit: This PR is also missing tests.

Edit2: Tests are failing because of dependency failures (the required [commit](6f5b85ebac2fc64aaface5242aa241bad720bc61) have not been published to crates.io yet :<