### PR TITLE
v0.10.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## [0.10.0] (2019-10-13)
+
+- Upgrade `rustsec` to v0.16; new self-audit system ([#155])
+- Upgrade to Abscissa v0.4; MSRV 1.36 ([#154])
+
 ## [0.9.3] (2019-10-08)
 
 - Update to `rustsec` crate v0.15.2 ([#149])
@@ -101,6 +106,9 @@
 
 - Initial release
 
+[0.10.0]: https://github.com/RustSec/cargo-audit/pull/156
+[#155]: https://github.com/RustSec/cargo-audit/pull/155
+[#154]: https://github.com/RustSec/cargo-audit/pull/154
 [0.9.3]: https://github.com/RustSec/cargo-audit/pull/150
 [#149]: https://github.com/RustSec/cargo-audit/pull/149
 [#148]: https://github.com/RustSec/cargo-audit/pull/148

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cargo-audit"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "abscissa_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "cargo-audit"
 description = "Audit Cargo.lock for crates with security vulnerabilities"
-version     = "0.9.3"
+version     = "0.10.0"
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/master/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/cargo-audit/0.9.3"
+    html_root_url = "https://docs.rs/cargo-audit/0.10.0"
 )]
 
 pub mod application;


### PR DESCRIPTION
- Upgrade `rustsec` to v0.16; new self-audit system (#155)
- Upgrade to Abscissa v0.4; MSRV 1.36 (#154)