### PR TITLE
Refactor `cargo audit fix` into a subcommand

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,6 +42,18 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v1
 
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
+
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -50,12 +62,18 @@ jobs:
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: -D warnings
         with:
           command: test
           args: --release
 
       - name: Run cargo test --all-features
         uses: actions-rs/cargo@v1
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: -D warnings
         with:
           command: test
           args: --all-features --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "abscissa_core"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "abscissa_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -176,7 +176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "cargo-audit"
 version = "0.10.0"
 dependencies = [
- "abscissa_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "abscissa_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo-edit 0.4.2 (git+https://github.com/killercup/cargo-edit)",
  "gumdrop 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "home 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1456,8 +1456,9 @@ dependencies = [
 [[package]]
 name = "rustsec"
 version = "0.16.0"
-source = "git+https://github.com/RustSec/rustsec-crate#35a939450c2ed51d4ef644d274203db0c7b510e5"
+source = "git+https://github.com/RustSec/rustsec-crate#de0257ee5152dedfec17da02a6b096e604af2191"
 dependencies = [
+ "cargo-edit 0.4.2 (git+https://github.com/killercup/cargo-edit)",
  "cargo-lock 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "crates-index 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2168,7 +2169,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum abscissa_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e09ff64ef3cdaf970afcfcac324b1975b18cd829e34a57485647d6f61b1734dd"
+"checksum abscissa_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "48e6300a8ec97b5f3f8f3096e6926443cceaf8f40ba7dc6c742ad79d9cf44b96"
 "checksum abscissa_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "74f5722bc48763cb9d81d8427ca05b6aa2842f6632cf8e4c0a29eef9baececcc"
 "checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition     = "2018"
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-abscissa_core = "0.5"
+abscissa_core = "0.5.1"
 gumdrop = "0.7"
 home = "0.5"
 lazy_static = "1"
@@ -44,4 +44,4 @@ version = "0.5"
 features = ["testing"]
 
 [features]
-fix = ["cargo-edit"]
+fix = ["rustsec/fix"]

--- a/audit.toml.example
+++ b/audit.toml.example
@@ -21,7 +21,6 @@ deny_warnings = false # exit on error if any warnings are found
 format = "terminal" # "terminal" (human readable report) or "json"
 quiet = false # Only print information on error
 show_tree = true # Show inverse dependency trees along with advisories (default: true)
-# fix = true # Automatically upgrade vulnerable dependencies (requires `fix` cargo feature)
 
 # Target Configuration
 [target]

--- a/src/commands/audit/fix.rs
+++ b/src/commands/audit/fix.rs
@@ -1,0 +1,75 @@
+//! The `cargo audit fix` subcommand
+
+use crate::{auditor::Auditor, prelude::*};
+use abscissa_core::{Command, Runnable};
+use gumdrop::Options;
+use rustsec::fixer::Fixer;
+use std::{
+    path::{Path, PathBuf},
+    process::exit,
+};
+
+#[derive(Command, Default, Debug, Options)]
+pub struct FixCommand {
+    /// Path to `Cargo.lock`
+    #[options(short = "f", long = "file", help = "Cargo lockfile to inspect")]
+    file: Option<PathBuf>,
+
+    /// Perform a dry run
+    #[options(no_short, long = "dry-run", help = "perform a dry run for the fix")]
+    dry_run: Option<bool>,
+}
+
+impl FixCommand {
+    /// Initialize `Auditor`
+    pub fn auditor(&self) -> Auditor {
+        let config = app_config();
+        Auditor::new(&config)
+    }
+
+    /// Locate `Cargo.toml`
+    // TODO(tarcieri): ability to specify path
+    pub fn cargo_toml_path(&self) -> PathBuf {
+        PathBuf::from("Cargo.toml")
+    }
+
+    /// Locate `Cargo.lock`
+    pub fn cargo_lock_path(&self) -> Option<&Path> {
+        self.file.as_ref().map(PathBuf::as_path)
+    }
+}
+
+impl Runnable for FixCommand {
+    fn run(&self) {
+        let report = self.auditor().audit(self.cargo_lock_path());
+
+        if report.vulnerabilities.list.is_empty() {
+            exit(0);
+        }
+
+        let mut fixer = Fixer::new(self.cargo_toml_path()).unwrap_or_else(|e| {
+            status_err!(
+                "couldn't load manifest from {}: {}",
+                self.cargo_toml_path().display(),
+                e
+            );
+            exit(1);
+        });
+
+        let dry_run = self.dry_run.unwrap_or_default();
+        let dry_run_info = if dry_run { " (dry run)" } else { "" };
+
+        status_ok!(
+            "Fixing",
+            "vulnerable dependencies in `{}`{}",
+            self.cargo_toml_path().display(),
+            dry_run_info
+        );
+
+        for vulnerability in &report.vulnerabilities.list {
+            if let Err(e) = fixer.fix(vulnerability, dry_run) {
+                status_warn!("{}", e);
+            }
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -113,23 +113,12 @@ pub struct OutputConfig {
 
     /// Show inverse dependency trees along with advisories (default: true)
     pub show_tree: Option<bool>,
-
-    /// Enable fix mode
-    #[cfg(feature = "fix")]
-    #[serde(default)]
-    pub fix: bool,
 }
 
 impl OutputConfig {
     /// Is quiet mode enabled?
     pub fn is_quiet(&self) -> bool {
         self.quiet || self.format == OutputFormat::Json
-    }
-
-    /// Is fix mode enabled?
-    #[cfg(feature = "fix")]
-    pub fn is_fix_enabled(&self) -> bool {
-        self.fix
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,12 +13,12 @@
 //!
 //! <https://docs.rs/rustsec/>
 
-#![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
-#![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/master/rustsec-logo-lg.png",
     html_root_url = "https://docs.rs/cargo-audit/0.10.0"
 )]
+#![forbid(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]
 
 pub mod application;
 pub mod auditor;


### PR DESCRIPTION
Splits out `audit fix` from `audit` into its own subcommand with its own arguments.

Uses `rustsec::fixer::Fixer` as the implementation.