### PR TITLE
v0.11.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+## [0.11.0] (2020-01-20)
+
+- Update `rustsec` crate to v0.17 release; MSRV 1.39+ ([#186], [#188])
+- Warn for yanked crates ([#180])
+- Respect sources of dependencies when auditing ([#175])
+- Upgrade to `abscissa` v0.5 ([#174])
+- `cargo audit fix` subcommand ([#157], [#166], [#181])
+
 ## [0.10.0] (2019-10-13)
 
 - Upgrade `rustsec` to v0.16; new self-audit system ([#155])
@@ -106,6 +114,15 @@
 
 - Initial release
 
+[0.11.0]: https://github.com/RustSec/cargo-audit/pull/189
+[#188]: https://github.com/RustSec/cargo-audit/pull/188
+[#186]: https://github.com/RustSec/cargo-audit/pull/186
+[#181]: https://github.com/RustSec/cargo-audit/pull/181
+[#180]: https://github.com/RustSec/cargo-audit/pull/180
+[#175]: https://github.com/RustSec/cargo-audit/pull/175
+[#174]: https://github.com/RustSec/cargo-audit/pull/174
+[#166]: https://github.com/RustSec/cargo-audit/pull/166
+[#157]: https://github.com/RustSec/cargo-audit/pull/157
 [0.10.0]: https://github.com/RustSec/cargo-audit/pull/156
 [#155]: https://github.com/RustSec/cargo-audit/pull/155
 [#154]: https://github.com/RustSec/cargo-audit/pull/154

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cargo-audit"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "abscissa_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gumdrop 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "cargo-audit"
 description = "Audit Cargo.lock for crates with security vulnerabilities"
-version     = "0.10.0"
+version     = "0.11.0"
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,28 @@ $ cargo install cargo-audit
 
 Once installed, run `cargo audit` at the toplevel of any Cargo project.
 
+## Screenshot
+
+<img src="https://github.com/RustSec/cargo-audit/raw/master/screenshot.png" alt="Screenshot" style="max-width:100%;">
+
+## `cargo audit fix` subcommand
+
+This tool supports an experimental feature to automatically update `Cargo.toml`
+to fix vulnerable dependency requirements.
+
+To enable it, install `cargo audit` with the `fix` feature enabled:
+
+```
+$ cargo install cargo-audit --features=fix
+```
+
+Once installed, run `cargo audit fix` to automatically fix vulnerable
+dependency requirements.
+
+This will modify `Cargo.toml` in place. To perform a dry run instead, which
+shows a preview of what dependencies would be upgraded, run
+`cargo audit fix --dry-run`.
+
 ## Using `cargo audit` on Travis CI
 
 To automatically run `cargo audit` on every build in Travis CI, you can add the following to your `.travis.yml`:
@@ -46,10 +68,6 @@ GitHub repo:
 <a href="https://github.com/RustSec/advisory-db/blob/master/CONTRIBUTING.md">
   <img alt="Report Vulnerability" width="250px" height="60px" src="https://rustsec.org/assets/img/report-vuln-button.svg">
 </a>
-
-## Screenshot
-
-<img src="https://github.com/RustSec/cargo-audit/raw/master/screenshot.png" alt="Screenshot" style="max-width:100%;">
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/master/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/cargo-audit/0.10.0"
+    html_root_url = "https://docs.rs/cargo-audit/0.11.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]


### PR DESCRIPTION
- Update `rustsec` crate to v0.17 release; MSRV 1.39+ (#186, #188)
- Warn for yanked crates (#180)
- Respect sources of dependencies when auditing (#175)
- Upgrade to `abscissa` v0.5 (#174)
- `cargo audit fix` subcommand (#157, #166, #181)