### PR TITLE
Add `vendored-openssl` feature (fixes #163)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,6 +1076,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.6.1+1.1.1d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91b04cb43c1a8a90e934e0cd612e2a5715d976d2d6cff4490278a0cddf35005"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,6 +1093,7 @@ dependencies = [
  "autocfg 0.1.7",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ features = ["testing"]
 
 [features]
 fix = ["rustsec/fix"]
+vendored-openssl = ["rustsec/vendored-openssl"]


### PR DESCRIPTION
This activates the corresponding feature in the `rustsec` crate, which instructs `git2` to build with a vendored copy of OpenSSL instead of the system one.