### PR TITLE
Wire up `-c`/`--color` command line argument (fixes #177)

### DIFF
--- a/audit.toml.example
+++ b/audit.toml.example
@@ -16,7 +16,6 @@ stale = false # Allow stale advisory DB (i.e. no commits for 90 days, default: f
 
 # Output Configuration
 [output]
-color = "auto" # Display colors? ("always", "never", or "auto")
 deny_warnings = false # exit on error if any warnings are found
 format = "terminal" # "terminal" (human readable report) or "json"
 quiet = false # Only print information on error

--- a/src/application.rs
+++ b/src/application.rs
@@ -5,7 +5,9 @@
 use crate::{commands::CargoAuditCommand, config::AuditConfig};
 use abscissa_core::{
     application::{self, AppCell},
-    config, trace, Application, EntryPoint, FrameworkError, StandardPaths,
+    config,
+    terminal::ColorChoice,
+    trace, Application, EntryPoint, FrameworkError, StandardPaths,
 };
 
 /// Application state
@@ -90,6 +92,15 @@ impl Application for CargoAuditApplication {
         self.state.components.after_config(&config)?;
         self.config = Some(config);
         Ok(())
+    }
+
+    /// Color configuration for this application.
+    fn term_colors(&self, entrypoint: &EntryPoint<CargoAuditCommand>) -> ColorChoice {
+        entrypoint
+            .command
+            .as_ref()
+            .and_then(|cmd| cmd.color_config())
+            .unwrap_or_else(|| ColorChoice::Auto)
     }
 
     /// Get tracing configuration from command-line options

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -5,7 +5,7 @@ mod audit;
 use self::audit::AuditCommand;
 use crate::config::AuditConfig;
 use abscissa_core::{config::Override, Command, Configurable, FrameworkError, Options, Runnable};
-use std::path::PathBuf;
+use std::{ops::Deref, path::PathBuf};
 
 /// Name of the configuration file (located in `~/.cargo`)
 ///
@@ -36,11 +36,19 @@ impl Configurable<AuditConfig> for CargoAuditCommand {
     }
 
     /// Override loaded config with explicit command-line arguments
-    /// `fix` update vulnerabilities with `cargo-edit`
-    /// `audit` match self
     fn process_config(&self, config: AuditConfig) -> Result<AuditConfig, FrameworkError> {
         match self {
             CargoAuditCommand::Audit(cmd) => cmd.override_config(config),
+        }
+    }
+}
+
+impl Deref for CargoAuditCommand {
+    type Target = AuditCommand;
+
+    fn deref(&self) -> &AuditCommand {
+        match self {
+            CargoAuditCommand::Audit(cmd) => cmd,
         }
     }
 }

--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -9,7 +9,7 @@ use crate::{
     config::{AuditConfig, OutputFormat},
     prelude::*,
 };
-use abscissa_core::{config::Override, FrameworkError};
+use abscissa_core::{config::Override, terminal::ColorChoice, FrameworkError};
 use gumdrop::Options;
 use rustsec::database::package_scope::PackageSource;
 use rustsec::platforms::target::{Arch, OS};
@@ -136,12 +136,19 @@ pub enum AuditSubcommand {
     Fix(FixCommand),
 }
 
+impl AuditCommand {
+    /// Get the color configuration
+    pub fn color_config(&self) -> Option<ColorChoice> {
+        self.color.as_ref().map(|colors| match colors.as_ref() {
+            "always" => ColorChoice::Always,
+            "never" => ColorChoice::Never,
+            _ => panic!("invalid color choice setting: {}", &colors),
+        })
+    }
+}
+
 impl Override<AuditConfig> for AuditCommand {
     fn override_config(&self, mut config: AuditConfig) -> Result<AuditConfig, FrameworkError> {
-        if let Some(color) = &self.color {
-            config.output.color = Some(color.clone());
-        }
-
         if let Some(db) = &self.db {
             config.database.path = Some(db.into());
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -97,9 +97,6 @@ pub struct DatabaseConfig {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OutputConfig {
-    /// Should colors be displayed?
-    pub color: Option<String>,
-
     /// Disallow any warning advisories
     #[serde(default)]
     pub deny_warnings: bool,


### PR DESCRIPTION
Looks like this was lost in the shuffle of the migration to Abscissa.

This adds support for introspecting the command line arguments from Abscissa's `term_colors` callback, extracting the `-c` option and using it to configure color preferences if present.

This removes the associated configuration options, as this setting is processed too early in the Abscissa application lifecycle for this option to be able to be read from the config.

It seems like Abscissa could use a few improvements here both to reduce the amount of boilerplate required to wire all of this up and also to allow color preferences to be loaded from configuration, however for now this is sufficient to make the option work.