### PR TITLE
Improve yanked crate auditing messages and config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,9 +1371,9 @@ checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
 name = "rustsec"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b3043847d5621931a19af1e028e86bece345932933235d76fe6cce049b9f05a"
+checksum = "de6b471e1ab0015cff3864141c2a1cad6a31cb3aba672aba7386e50a51e53db0"
 dependencies = [
  "cargo-edit",
  "cargo-lock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ abscissa_core = "0.5.2"
 gumdrop = "0.7"
 home = "0.5"
 lazy_static = "1"
-rustsec = { version = "0.17.1", features = ["dependency-tree"] }
+rustsec = { version = "0.18", features = ["dependency-tree"] }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 thiserror = "1"

--- a/audit.toml.example
+++ b/audit.toml.example
@@ -28,3 +28,7 @@ os = "linux" # Ignore advisories for operating systems other than this one
 
 [packages]
 source = "all" # "all", "public" or "local"
+
+[yanked]
+enabled = true # Warn for yanked crates in Cargo.lock (default: true)
+update_index = true # Auto-update the crates.io index (default: true)

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,19 +16,28 @@ use std::path::PathBuf;
 #[serde(deny_unknown_fields)]
 pub struct AuditConfig {
     /// Advisory-related configuration
+    #[serde(default)]
     pub advisories: AdvisoryConfig,
 
     /// Advisory Database configuration
+    #[serde(default)]
     pub database: DatabaseConfig,
 
     /// Output configuration
+    #[serde(default)]
     pub output: OutputConfig,
 
     /// Target-related configuration
+    #[serde(default)]
     pub target: TargetConfig,
 
     /// Packages-related configuration
+    #[serde(default)]
     pub packages: PackageConfig,
+
+    /// Configuration for auditing for yanked crates
+    #[serde(default)]
+    pub yanked: YankedConfig,
 }
 
 impl AuditConfig {
@@ -154,4 +163,31 @@ pub struct TargetConfig {
 pub struct PackageConfig {
     /// Package scope which should be considered for querying for vulnerabilities.
     pub source: Option<PackageSource>,
+}
+
+/// Configuration for auditing for yanked crates
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct YankedConfig {
+    /// Is auditing for yanked crates enabled?
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
+    /// Should the crates.io index be updated before checking for yanked crates?
+    #[serde(default = "default_true")]
+    pub update_index: bool,
+}
+
+impl Default for YankedConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            update_index: true,
+        }
+    }
+}
+
+/// Helper function for returning a default of `true`
+fn default_true() -> bool {
+    true
 }


### PR DESCRIPTION
Upgrades to `rustsec` crate v0.18.

This commit moves the functionality of the `find_yanked_crates()` function which was previously located in the `rustsec` crate into `cargo-audit` itself, which allows printing contextual messages about its interactions with the crates.io index:

https://github.com/RustSec/rustsec-crate/pull/147

It also adds config options to disable auditing for yanked crates, or to disable fetching the crates.io index before checking for yanked crates.