### PR TITLE
Update backtrace to v0.3.44

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,9 +115,9 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
-version = "0.3.42"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b1549d804b6c73f4817df2ba073709e96e426f12987127c48e6745568c350b"
+checksum = "e4036b9bf40f3cf16aba72a3d65e8a520fc4bafcdc7079aea8f848c58c5b5536"
 dependencies = [
  "backtrace-sys",
  "cfg-if",


### PR DESCRIPTION
Version 0.3.42 used previously has been yanked, causing self-audit warnings. The reason it was yanked was due to some versioning issue with the `cfg-if` dependency, so it's not a security issue but it does cause CI to fail.

See <https://github.com/rust-lang/backtrace-rs/issues/285>.