### PR TITLE
specify deny-warning types

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -92,7 +92,7 @@ jobs:
           override: true
 
       - name: Run cargo audit
-        run: cargo run -- audit --deny-warnings --ignore RUSTSEC-2019-0031
+        run: cargo run -- audit --deny-warnings all --ignore RUSTSEC-2019-0031
 
   fmt:
     name: Rustfmt

--- a/audit.toml.example
+++ b/audit.toml.example
@@ -16,7 +16,7 @@ stale = false # Allow stale advisory DB (i.e. no commits for 90 days, default: f
 
 # Output Configuration
 [output]
-deny_warnings = ["all"] # exit on error if any warnings are found
+deny_warnings = ["unmaintained", "other"] # exit on error if any warnings are found
 format = "terminal" # "terminal" (human readable report) or "json"
 quiet = false # Only print information on error
 show_tree = true # Show inverse dependency trees along with advisories (default: true)

--- a/audit.toml.example
+++ b/audit.toml.example
@@ -16,7 +16,7 @@ stale = false # Allow stale advisory DB (i.e. no commits for 90 days, default: f
 
 # Output Configuration
 [output]
-deny_warnings = ["unmaintained", "other"] # exit on error if any warnings are found
+deny_warnings = ["unmaintained", "other"] # exit on error if unmaintained or other warnings are found
 format = "terminal" # "terminal" (human readable report) or "json"
 quiet = false # Only print information on error
 show_tree = true # Show inverse dependency trees along with advisories (default: true)

--- a/audit.toml.example
+++ b/audit.toml.example
@@ -16,7 +16,7 @@ stale = false # Allow stale advisory DB (i.e. no commits for 90 days, default: f
 
 # Output Configuration
 [output]
-deny_warnings = false # exit on error if any warnings are found
+deny_warnings = ["all"] # exit on error if any warnings are found
 format = "terminal" # "terminal" (human readable report) or "json"
 quiet = false # Only print information on error
 show_tree = true # Show inverse dependency trees along with advisories (default: true)

--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -6,7 +6,7 @@ mod fix;
 use super::CargoAuditCommand;
 use crate::{
     auditor::Auditor,
-    config::{AuditConfig, OutputFormat, WarningKind},
+    config::{AuditConfig, DenyWarningOption, OutputFormat},
     prelude::*,
 };
 use abscissa_core::{config::Override, terminal::ColorChoice, FrameworkError};
@@ -19,7 +19,7 @@ use std::{path::PathBuf, process::exit};
 use self::fix::FixCommand;
 
 /// The `cargo audit` subcommand
-#[derive(Command, Default, Debug, Options)]
+#[derive(Default, Debug, Options, Command)]
 pub struct AuditCommand {
     /// Optional subcommand (used for `cargo audit fix`)
     #[cfg(feature = "fix")]
@@ -55,7 +55,7 @@ pub struct AuditCommand {
         long = "deny-warnings",
         help = "exit with an error if any warning advisories of specified kinds are found"
     )]
-    deny_warnings: Vec<WarningKind>,
+    deny_warnings: Vec<DenyWarningOption>,
 
     /// Path to `Cargo.lock`
     #[options(
@@ -180,11 +180,11 @@ impl Override<AuditConfig> for AuditCommand {
 
         for kind in &self.deny_warnings {
             match kind {
-                WarningKind::All => {
+                DenyWarningOption::All => {
                     config.output.deny_warnings = vec![
-                        WarningKind::Other,
-                        WarningKind::Unmaintained,
-                        WarningKind::Yanked,
+                        DenyWarningOption::Other,
+                        DenyWarningOption::Unmaintained,
+                        DenyWarningOption::Yanked,
                     ]
                 }
                 k => config.output.deny_warnings.push(k.clone()),

--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -19,7 +19,7 @@ use std::{path::PathBuf, process::exit};
 use self::fix::FixCommand;
 
 /// The `cargo audit` subcommand
-#[derive(Default, Debug, Options, Command)]
+#[derive(Command, Default, Debug, Options)]
 pub struct AuditCommand {
     /// Optional subcommand (used for `cargo audit fix`)
     #[cfg(feature = "fix")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -154,12 +154,12 @@ pub enum DenyWarningOption {
 impl DenyWarningOption {
     /// Get the warning::Kind that corresponds to self, if applicable
     pub fn get_warning_kind(&self) -> Option<warning::Kind> {
-        return match self {
+        match self {
             DenyWarningOption::All => None,
             DenyWarningOption::Other => None,
             DenyWarningOption::Unmaintained => Some(warning::Kind::Unmaintained),
             DenyWarningOption::Yanked => Some(warning::Kind::Yanked),
-        };
+        }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,5 @@
 //! The `~/.cargo/audit.toml` configuration file
 
-use rustsec::database::package_scope::{PackageScope, PackageSource};
 use rustsec::warning;
 use rustsec::{
     advisory,

--- a/src/config.rs
+++ b/src/config.rs
@@ -153,7 +153,7 @@ pub enum DenyWarningOption {
 
 impl DenyWarningOption {
     /// Get the warning::Kind that corresponds to self, if applicable
-    pub fn get_warning_kind(&self) -> Option<warning::Kind> {
+    pub fn get_warning_kind(self) -> Option<warning::Kind> {
         match self {
             DenyWarningOption::All => None,
             DenyWarningOption::Other => None,

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -97,18 +97,10 @@ impl Presenter {
             self.print_vulnerability(vulnerability, &tree);
         }
 
-        // sort warning::Kinds alphabetically
-        let mut sorted_keys: Vec<&warning::Kind> = report
-            .warnings
-            .warnings
-            .keys()
-            .collect::<Vec<&warning::Kind>>();
-        sorted_keys.sort();
-
         let mut num_denied: u64 = 0;
         let mut num_not_denied: u64 = 0;
 
-        for kind in &sorted_keys {
+        for kind in report.warnings.warnings.keys() {
             if self.deny_warning_kinds.contains(kind) {
                 num_denied += report.warnings.warnings.get(kind).unwrap().len() as u64;
             } else {
@@ -124,7 +116,7 @@ impl Presenter {
             self.warning_word(num_not_denied)
         );
 
-        for kind in &sorted_keys {
+        for kind in report.warnings.warnings.keys() {
             for warning in report.warnings.warnings.get(kind).unwrap() {
                 self.print_warning(warning, &tree)
             }

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -108,7 +108,7 @@ impl Presenter {
             }
         }
 
-        status_err!("{} {} found", num_denied, self.warning_word(num_denied));
+        status_err!("{} {} found!", num_denied, self.warning_word(num_denied));
 
         status_warn!(
             "{} {} found",

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -100,11 +100,11 @@ impl Presenter {
         let mut num_denied: u64 = 0;
         let mut num_not_denied: u64 = 0;
 
-        for kind in report.warnings.warnings.keys() {
+        for kind in report.warnings.keys() {
             if self.deny_warning_kinds.contains(kind) {
-                num_denied += report.warnings.warnings.get(kind).unwrap().len() as u64;
+                num_denied += report.warnings.get(kind).unwrap().len() as u64;
             } else {
-                num_not_denied += report.warnings.warnings.get(kind).unwrap().len() as u64;
+                num_not_denied += report.warnings.get(kind).unwrap().len() as u64;
             }
         }
 
@@ -116,8 +116,8 @@ impl Presenter {
             self.warning_word(num_not_denied)
         );
 
-        for kind in report.warnings.warnings.keys() {
-            for warning in report.warnings.warnings.get(kind).unwrap() {
+        for kind in report.warnings.keys() {
+            for warning in report.warnings.get(kind).unwrap() {
                 self.print_warning(warning, &tree)
             }
         }


### PR DESCRIPTION
Dependent on modifications in rustsec (https://github.com/RustSec/rustsec-crate/pull/156)

========

This is an initial attempt at #195 that I'm hoping for some feedback on.

I erred towards not modifying the `rustsec` crate in the approach here because I wasn't sure about the crates that depend on `rustsec`, but I think it could be cleaner to do some work there, such as:
- have the `Report` struct have something like a `WarningInfo` struct (to replace the `Vec<Warning>`)
- have the `WarningInfo` struct essentially be a hashmap of `warning::Type` to `Vec<Warning>`
- modify `Warning` and/or `warning::Type` to better support the hashmap of warning types to lists of warnings; e.g. maybe ideally `warning::Type` enum (or something like it) would not hold data