### PR TITLE
Regenerate lockfile after `cargo audit fix`

### DIFF
--- a/src/auditor.rs
+++ b/src/auditor.rs
@@ -1,11 +1,11 @@
 //! Core auditing functionality
 
-use crate::{config::AuditConfig, error::Error, prelude::*, presenter::Presenter};
+use crate::{config::AuditConfig, error::Error, lockfile, prelude::*, presenter::Presenter};
 use rustsec::{lockfile::Lockfile, registry, report, warning, Warning};
 use std::{
     io::{self, Read},
     path::Path,
-    process::{exit, Command},
+    process::exit,
 };
 
 /// Name of `Cargo.lock`
@@ -120,7 +120,7 @@ impl Auditor {
             let path = Path::new(CARGO_LOCK_FILE);
 
             if !path.exists() && Path::new("Cargo.toml").exists() {
-                generate_lockfile();
+                lockfile::generate();
             }
 
             path
@@ -189,29 +189,5 @@ impl Auditor {
         }
 
         results
-    }
-}
-
-/// Run `cargo generate-lockfile`
-fn generate_lockfile() {
-    let status = Command::new("cargo")
-        .arg("generate-lockfile")
-        .status()
-        .unwrap_or_else(|e| {
-            status_err!("couldn't run `cargo generate-lockfile`: {}", e);
-            exit(1);
-        });
-
-    if !status.success() {
-        if let Some(code) = status.code() {
-            status_err!(
-                "non-zero exit status running `cargo generate-lockfile`: {}",
-                code
-            );
-        } else {
-            status_err!("no exit status running `cargo generate-lockfile`!");
-        }
-
-        exit(1);
     }
 }

--- a/src/commands/audit/fix.rs
+++ b/src/commands/audit/fix.rs
@@ -1,6 +1,6 @@
 //! The `cargo audit fix` subcommand
 
-use crate::{auditor::Auditor, prelude::*};
+use crate::{auditor::Auditor, lockfile, prelude::*};
 use abscissa_core::{Command, Runnable};
 use gumdrop::Options;
 use rustsec::fixer::Fixer;
@@ -79,5 +79,7 @@ impl Runnable for FixCommand {
                 status_warn!("{}", e);
             }
         }
+
+        lockfile::generate();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod auditor;
 pub mod commands;
 pub mod config;
 pub mod error;
+pub mod lockfile;
 mod prelude;
 pub mod presenter;
 

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1,0 +1,28 @@
+//! Cargo.lock-related utilities
+
+use crate::prelude::*;
+use std::process::{exit, Command};
+
+/// Run `cargo generate-lockfile`
+pub fn generate() {
+    let status = Command::new("cargo")
+        .arg("generate-lockfile")
+        .status()
+        .unwrap_or_else(|e| {
+            status_err!("couldn't run `cargo generate-lockfile`: {}", e);
+            exit(1);
+        });
+
+    if !status.success() {
+        if let Some(code) = status.code() {
+            status_err!(
+                "non-zero exit status running `cargo generate-lockfile`: {}",
+                code
+            );
+        } else {
+            status_err!("no exit status running `cargo generate-lockfile`!");
+        }
+
+        exit(1);
+    }
+}


### PR DESCRIPTION
Ensures changes to Cargo.toml are applied to Cargo.lock after the `fix` command has been run.