### PR TITLE
v0.12.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## [0.12.0] (2020-05-06)
+
+- Update `rustsec` crate to v0.20 ([#221])
+- Regenerate lockfile after `cargo audit fix` ([#219])
+- Update dependencies; MSRV 1.40+ ([#216])
+
 ## [0.11.2] (2020-02-07)
 
 - Improve yanked crate auditing messages and config ([#200])
@@ -123,6 +129,10 @@
 
 - Initial release
 
+[0.12.0]: https://github.com/RustSec/cargo-audit/pull/222
+[#221]: https://github.com/RustSec/cargo-audit/pull/221
+[#219]: https://github.com/RustSec/cargo-audit/pull/219
+[#216]: https://github.com/RustSec/cargo-audit/pull/216
 [0.11.2]: https://github.com/RustSec/cargo-audit/pull/201
 [#200]: https://github.com/RustSec/cargo-audit/pull/200
 [#199]: https://github.com/RustSec/cargo-audit/pull/199

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
 
 [[package]]
 name = "cargo-audit"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "abscissa_core",
  "gumdrop",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "cargo-audit"
 description = "Audit Cargo.lock for crates with security vulnerabilities"
-version     = "0.11.2"
+version     = "0.12.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/master/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/cargo-audit/0.11.2"
+    html_root_url = "https://docs.rs/cargo-audit/0.12.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]


### PR DESCRIPTION
- Update `rustsec` crate to v0.20 (#221)
- Regenerate lockfile after `cargo audit fix` (#219)
- Update dependencies; MSRV 1.40+ (#216)