### PR TITLE
Add support for project specific config directories

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -24,12 +24,22 @@ impl Configurable<AuditConfig> for CargoAuditCommand {
     /// Location of `audit.toml` (if it exists)
     fn config_path(&self) -> Option<PathBuf> {
         // Check if the config file exists, and if it does not, ignore it.
-        let filename = home::cargo_home()
+        //
+        // The order of precedence for which config file to use is:
+        // 1. The current project's `.cargo` configuration directory.
+        // 2. The current user's home directory configuration.
+
+        let project_config_filename = PathBuf::from("./.cargo").join(CONFIG_FILE);
+        if project_config_filename.exists() {
+            return Some(project_config_filename);
+        }
+
+        let home_config_filename = home::cargo_home()
             .ok()
             .map(|cargo_home| cargo_home.join(CONFIG_FILE))?;
 
-        if filename.exists() {
-            Some(filename)
+        if home_config_filename.exists() {
+            Some(home_config_filename)
         } else {
             None
         }


### PR DESCRIPTION
I noticed that when trying to use a config file in a project/workspace directory (`projectname/.cargo/audit.toml`) `cargo-audit` didn't pick up on the configuration file. After checking the source I found that it only can use configurations from the users home directory, which imo is slightly prohibitive in the situations you can use it for. For example, it would be difficult to have a work `cargo-audit` configuration that may be more strict compared to one for your hobby projects.  

The order I chose for checking for config directories (I added a code comment as well about it) is:
1. The project specific cargo configuration directory
2. The user's home directory located configuration. 

I went for this approach because [it lines up with how cargo itself searches for configurations](https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure). I think this could be considered a breaking change in theory but I doubt it would have any impact since user's likely won't have an `audit.toml` file in their repository-specific config right now. 

This would also be pretty helpful for CI setups too, like I'd like to setup on a personal project, so advisories and outputs can be configured "globally" between a developer using them and CI without having to repeat flags everywhere. 