### PR TITLE
pin smol_str to 0.1.16 to support Rust 1.44 or older

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,7 @@ dependencies = [
  "rustsec",
  "serde",
  "serde_json",
+ "smol_str",
  "tempfile",
  "thiserror",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = "1"
 once_cell = "1.3"
 tempfile = "3"
 toml = "0.5"
+smol_str = "=0.1.16" # smol_str 0.1.17 is incompatible with Rust 1.44 or lower
 
 [dev-dependencies.abscissa_core]
 version = "0.5"


### PR DESCRIPTION
`smol_str` crate is used in `cargo-audit` through `crates-index`. `smol_str` MSRV is current stable version of Rust, while `cargo-audit` MSRV is 1.40. This PR pins `smol_str` version to one that works with older Rust versions.

fixes #254