### PR TITLE
.github: ignore RUSTSEC-2020-0036 in self-audit

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -92,7 +92,10 @@ jobs:
           override: true
 
       - name: Run cargo audit
-        run: cargo run -- audit --deny-warnings all --ignore RUSTSEC-2019-0031 --ignore RUSTSEC-2020-0016
+        run: >
+          cargo run -- audit --deny-warnings all
+          --ignore RUSTSEC-2020-0016
+          --ignore RUSTSEC-2020-0036
 
   fmt:
     name: Rustfmt


### PR DESCRIPTION
This is a deprecation notice for the `failure` crate.

It was widely used, so it will probably be awhile before it's removed from all of our transitive dependencies.