### PR TITLE
move smol_str to dependencies from dev-dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,7 @@ dependencies = [
  "rustsec",
  "serde",
  "serde_json",
+ "smol_str",
  "tempfile",
  "thiserror",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = "1"
 once_cell = "1.3"
 tempfile = "3"
 toml = "0.5"
+smol_str = "=0.1.16" # smol_str 0.1.17 is incompatible with Rust 1.44 or lower
 
 [dev-dependencies.abscissa_core]
 version = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,13 @@ lazy_static = "1"
 rustsec = { version = "0.20", features = ["dependency-tree"] }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
+smol_str = "=0.1.16" # smol_str 0.1.17 is incompatible with Rust 1.44 or lower
 thiserror = "1"
 
 [dev-dependencies]
 once_cell = "1.3"
 tempfile = "3"
 toml = "0.5"
-smol_str = "=0.1.16" # smol_str 0.1.17 is incompatible with Rust 1.44 or lower
 
 [dev-dependencies.abscissa_core]
 version = "0.5"


### PR DESCRIPTION
i've tried `cargo install --git https://github.com/galich/cargo-audit.git --branch move-smol-to-deps` and it was working with Rust 1.44