### PR TITLE
v0.12.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## [0.12.1] (2020-09-22)
+
+- Pin `smol_str` to v0.1.16 to ensure MSRV 1.41 compatibility ([#255], [#258])
+
 ## [0.12.0] (2020-05-06)
 
 - Update `rustsec` crate to v0.20 ([#221])
@@ -129,6 +133,9 @@
 
 - Initial release
 
+[0.12.1]: https://github.com/RustSec/cargo-audit/pull/260
+[#258]: https://github.com/RustSec/cargo-audit/pull/258
+[#255]: https://github.com/RustSec/cargo-audit/pull/255
 [0.12.0]: https://github.com/RustSec/cargo-audit/pull/222
 [#221]: https://github.com/RustSec/cargo-audit/pull/221
 [#219]: https://github.com/RustSec/cargo-audit/pull/219

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
 
 [[package]]
 name = "cargo-audit"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "abscissa_core",
  "gumdrop",
@@ -182,6 +182,7 @@ dependencies = [
  "rustsec",
  "serde",
  "serde_json",
+ "smol_str",
  "tempfile",
  "thiserror",
  "toml",
@@ -1516,9 +1517,9 @@ checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 
 [[package]]
 name = "smol_str"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34836c9a295c62c2ce3514471117c5cb269891e8421b2aafdd910050576c4d8b"
+checksum = "2f7909a1d8bc166a862124d84fdc11bda0ea4ed3157ccca662296919c2972db1"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "cargo-audit"
 description = "Audit Cargo.lock for crates with security vulnerabilities"
-version     = "0.12.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.12.1" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"
@@ -22,6 +22,7 @@ lazy_static = "1"
 rustsec = { version = "0.20", features = ["dependency-tree"] }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
+smol_str = "=0.1.16" # smol_str 0.1.17 is incompatible with Rust 1.44 or lower
 thiserror = "1"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/master/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/cargo-audit/0.12.0"
+    html_root_url = "https://docs.rs/cargo-audit/0.12.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]


### PR DESCRIPTION
- Pin `smol_str` to v0.1.16 to ensure MSRV 1.41 compatibility (#255, #258)