### PR TITLE
Revert "Bump `rustsec` crate to v0.22; MSRV 1.41+"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,3 @@
-# Based on https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
-
 name: CI
 
 on:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
  "once_cell",
  "regex",
  "secrecy",
- "semver 0.9.0",
+ "semver",
  "serde",
  "signal-hook",
  "termcolor",
@@ -154,37 +154,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-dependencies = [
- "block-padding",
- "byte-tools",
- "byteorder",
- "generic-array",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -214,9 +187,9 @@ dependencies = [
  "lazy_static",
  "once_cell",
  "rustsec",
- "semver-parser 0.10.0",
  "serde",
  "serde_json",
+ "smol_str",
  "tempfile",
  "thiserror",
  "toml",
@@ -224,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-edit"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e134b2890bf9998402c781fe18798f3c82bc555dee24e8ba25e6cd0c40c7b0d"
+checksum = "96c6c218e759311574120f7ac8fd6b0c3ed155e1240c00f751a2f47c10068e8a"
 dependencies = [
  "atty",
  "cargo_metadata",
@@ -238,7 +211,7 @@ dependencies = [
  "hex",
  "regex",
  "reqwest",
- "semver 0.11.0",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",
@@ -252,12 +225,12 @@ dependencies = [
 
 [[package]]
 name = "cargo-lock"
-version = "6.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad00408e56f778335802ea240b8d70bebf6ea6c43c7508ebb6259431b5f16c2"
+checksum = "8504b63dd1249fd1745b7b4ef9b6f7b107ddeb3c95370043c7dbcc38653a2679"
 dependencies = [
  "petgraph",
- "semver 0.11.0",
+ "semver",
  "serde",
  "toml",
  "url",
@@ -265,12 +238,13 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.11.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a567c24b86754d629addc2db89e340ac9398d07b5875efcff837e3878e17ec"
+checksum = "46e3374c604fb39d1a2f35ed5e4a4e30e60d01fab49446e08f1b3e9a90aef202"
 dependencies = [
- "semver 0.10.0",
+ "semver",
  "serde",
+ "serde_derive",
  "serde_json",
 ]
 
@@ -372,20 +346,18 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "crates-index"
-version = "0.16.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ae75100b8f15499dd7340cb39da61afe7d27bee726038a09d143600901331e"
+checksum = "15467291e8911aa3e73b0e77d988362da1df7ac974c7189ab38b94b6f7edfa7e"
 dependencies = [
  "git2",
  "glob",
  "hex",
  "home",
- "memchr",
- "semver 0.11.0",
  "serde",
  "serde_derive",
  "serde_json",
- "smartstring",
+ "smol_str",
 ]
 
 [[package]]
@@ -444,20 +416,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "dirs"
-version = "3.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
+checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 dependencies = [
+ "cfg-if 0.1.10",
  "dirs-sys",
 ]
 
@@ -536,12 +500,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-
-[[package]]
 name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,12 +525,6 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "fs-err"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcd1163ae48bda72a20ae26d66a04d3094135cadab911cff418ae5e33f253431"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -648,15 +600,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e1d3b771574f62d0548cee0ad9057857e9fc25d7a3335f140c84f6acd0bf601"
 dependencies = [
  "cfg-if 0.1.10",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
-dependencies = [
- "typenum",
 ]
 
 [[package]]
@@ -993,12 +936,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maplit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
 name = "matchers"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,12 +1090,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
 
 [[package]]
-name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-
-[[package]]
 name = "openssl"
 version = "0.10.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,49 +1146,6 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
-
-[[package]]
-name = "pest"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-dependencies = [
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
-dependencies = [
- "maplit",
- "pest",
- "sha-1",
-]
 
 [[package]]
 name = "petgraph"
@@ -1329,9 +1217,9 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "platforms"
-version = "1.0.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b293f8e1b9172c3090804c6dedc31b0a61d382101dd4abc80aa6df5bd52e878"
+checksum = "feb3b2b1033b8a60b4da6ee470325f887758c95d5320f52f9ce0df055a55940e"
 dependencies = [
  "serde",
 ]
@@ -1534,22 +1422,21 @@ checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
 
 [[package]]
 name = "rustsec"
-version = "0.22.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf1938cfa0b260671c542ec11454a5675468e09d0fc20d9f764b7c312d6534b"
+checksum = "b2f7c2b431b329341b1ee7193b7403269153b99804ff5850a0b8966aed26f558"
 dependencies = [
  "cargo-edit",
  "cargo-lock",
  "chrono",
  "crates-index",
  "cvss",
- "fs-err",
  "git2",
  "home",
  "platforms",
- "semver 0.11.0",
+ "semver",
+ "semver-parser 0.9.0",
  "serde",
- "smol_str",
  "thiserror",
  "toml",
 ]
@@ -1614,26 +1501,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
-dependencies = [
- "semver-parser 0.7.0",
- "serde",
-]
-
-[[package]]
-name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser 0.10.0",
- "serde",
-]
-
-[[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1641,13 +1508,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
-version = "0.10.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e012c6c5380fb91897ba7b9261a0f565e624e869d42fe1a1d03fa0d68a083d5"
-dependencies = [
- "pest",
- "pest_derive",
-]
+checksum = "b46e1121e8180c12ff69a742aabc4f310542b6ccb69f1691689ac17fdf8618aa"
 
 [[package]]
 name = "serde"
@@ -1693,18 +1556,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
-dependencies = [
- "block-buffer",
- "digest",
- "fake-simd",
- "opaque-debug",
-]
-
-[[package]]
 name = "signal-hook"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1740,20 +1591,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "smartstring"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5579edba9651e6b9ccf0d516c4457521a149dadeb77e88b03eb1ae3183fe180a"
-dependencies = [
- "serde",
- "static_assertions",
-]
-
-[[package]]
 name = "smol_str"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f7909a1d8bc166a862124d84fdc11bda0ea4ed3157ccca662296919c2972db1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -1772,12 +1616,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1979,9 +1817,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.2.0"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09391a441b373597cf0888d2b052dcf82c5be4fee05da3636ae30fb57aad8484"
+checksum = "87f53b1aca7d5fe2e17498a38cac0e1f5a33234d5b980fb36b9402bb93b98ae4"
 dependencies = [
  "chrono",
  "combine",
@@ -2070,18 +1908,6 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
-
-[[package]]
-name = "typenum"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ abscissa_core = "0.5.2"
 gumdrop = "0.7"
 home = "0.5"
 lazy_static = "1"
-rustsec = { version = "0.22", features = ["dependency-tree", "fetch"] }
+rustsec = { version = "0.21.0", features = ["dependency-tree"] }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
-semver-parser = { version = "=0.10.0", optional = true } # Workardound for build failure?!
+smol_str = "=0.1.16" # smol_str 0.1.17 is incompatible with Rust 1.44 or lower
 thiserror = "1"
 
 [dev-dependencies]
@@ -35,5 +35,5 @@ version = "0.5"
 features = ["testing"]
 
 [features]
-fix = ["rustsec/fix", "semver-parser"]
+fix = ["rustsec/fix"]
 vendored-openssl = ["rustsec/vendored-openssl"]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Audit `Cargo.lock` files for crates with security vulnerabilities reported to th
 
 ## Requirements
 
-`cargo audit` requires Rust **1.41** or later.
+`cargo audit` requires Rust **1.40** or later.
 
 ## Installation
 
@@ -97,7 +97,7 @@ additional terms or conditions.
 [build-image]: https://github.com/rustsec/cargo-audit/workflows/CI/badge.svg?branch=master&event=push
 [build-link]: https://github.com/RustSec/cargo-audit/actions?query=workflow:CI+branch:master
 [license-image]: https://img.shields.io/badge/license-Apache2.0%2FMIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.40+-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg

--- a/src/auditor.rs
+++ b/src/auditor.rs
@@ -35,37 +35,33 @@ impl Auditor {
             .url
             .as_ref()
             .map(AsRef::as_ref)
-            .unwrap_or(rustsec::repository::git::DEFAULT_URL);
+            .unwrap_or(rustsec::repository::DEFAULT_URL);
 
         let advisory_db_path = config
             .database
             .path
             .as_ref()
             .cloned()
-            .unwrap_or_else(rustsec::GitRepository::default_path);
+            .unwrap_or_else(rustsec::Repository::default_path);
 
         let advisory_db_repo = if config.database.fetch {
             if !config.output.is_quiet() {
                 status_ok!("Fetching", "advisory database from `{}`", advisory_db_url);
             }
 
-            rustsec::GitRepository::fetch(
-                advisory_db_url,
-                &advisory_db_path,
-                !config.database.stale,
-            )
-            .unwrap_or_else(|e| {
-                status_err!("couldn't fetch advisory database: {}", e);
-                exit(1);
-            })
+            rustsec::Repository::fetch(advisory_db_url, &advisory_db_path, !config.database.stale)
+                .unwrap_or_else(|e| {
+                    status_err!("couldn't fetch advisory database: {}", e);
+                    exit(1);
+                })
         } else {
-            rustsec::GitRepository::open(&advisory_db_path).unwrap_or_else(|e| {
+            rustsec::Repository::open(&advisory_db_path).unwrap_or_else(|e| {
                 status_err!("couldn't open advisory database: {}", e);
                 exit(1);
             })
         };
 
-        let database = rustsec::Database::load_from_repo(&advisory_db_repo).unwrap_or_else(|e| {
+        let database = rustsec::Database::load(&advisory_db_repo).unwrap_or_else(|e| {
             status_err!("error loading advisory database: {}", e);
             exit(1);
         });
@@ -147,7 +143,7 @@ impl Auditor {
             for package in &lockfile.packages {
                 if let Ok(pkg) = index.find(&package.name, &package.version) {
                     if pkg.is_yanked {
-                        let warning = Warning::new(warning::Kind::Yanked, package, None);
+                        let warning = Warning::new(warning::Kind::Yanked, package, None, None);
                         match report.warnings.entry(warning::Kind::Yanked) {
                             map::Entry::Occupied(entry) => (*entry.into_mut()).push(warning),
                             map::Entry::Vacant(entry) => {

--- a/src/commands/audit/fix.rs
+++ b/src/commands/audit/fix.rs
@@ -4,7 +4,6 @@ use crate::{auditor::Auditor, lockfile, prelude::*};
 use abscissa_core::{Command, Runnable};
 use gumdrop::Options;
 use rustsec::fixer::Fixer;
-use rustsec::Vulnerability;
 use std::{
     path::{Path, PathBuf},
     process::exit,
@@ -75,13 +74,8 @@ impl Runnable for FixCommand {
             dry_run_info
         );
 
-        for vulnerability_info in &report.vulnerabilities.list {
-            let vulnerability = Vulnerability {
-                advisory: vulnerability_info.to_advisory(),
-                package: vulnerability_info.package.clone(),
-            };
-
-            if let Err(e) = fixer.fix(&vulnerability, dry_run) {
+        for vulnerability in &report.vulnerabilities.list {
+            if let Err(e) = fixer.fix(vulnerability, dry_run) {
                 status_warn!("{}", e);
             }
         }

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -111,8 +111,8 @@ impl Presenter {
             }
 
             for advisory in self_advisories {
-                self.print_advisory(
-                    &advisory,
+                self.print_metadata(
+                    &advisory.metadata,
                     self.warning_color(
                         self.config
                             .deny_warnings
@@ -186,7 +186,7 @@ impl Presenter {
     /// Print information about the given vulnerability
     fn print_vulnerability(
         &mut self,
-        vulnerability: &rustsec::report::VulnerabilityInfo,
+        vulnerability: &rustsec::Vulnerability,
         tree: &dependency::Tree,
     ) {
         self.print_attr(Red, "Crate:        ", &vulnerability.package.name);
@@ -195,7 +195,7 @@ impl Presenter {
             "Version:      ",
             &vulnerability.package.version.to_string(),
         );
-        self.print_advisory(&vulnerability.to_advisory(), Red);
+        self.print_metadata(&vulnerability.advisory, Red);
 
         if vulnerability.versions.patched.is_empty() {
             self.print_attr(Red, "Solution:     ", "No safe upgrade is available!");
@@ -203,17 +203,15 @@ impl Presenter {
             self.print_attr(
                 Red,
                 "Solution:     ",
-                format!(
-                    "Upgrade to {}",
-                    vulnerability
+                String::from("Upgrade to ")
+                    + &vulnerability
                         .versions
                         .patched
                         .iter()
                         .map(ToString::to_string)
                         .collect::<Vec<_>>()
                         .as_slice()
-                        .join(" OR ")
-                ),
+                        .join(" OR "),
             );
         }
 
@@ -234,7 +232,7 @@ impl Presenter {
         self.print_attr(color, "Warning:      ", warning.kind.as_str());
 
         if let Some(metadata) = &warning.advisory {
-            self.print_advisory(metadata, color)
+            self.print_metadata(metadata, color)
         }
 
         self.print_tree(color, &warning.package, tree);
@@ -251,14 +249,14 @@ impl Presenter {
     }
 
     /// Print a warning about a particular advisory
-    fn print_advisory(&self, advisory: &rustsec::Advisory, color: Color) {
-        self.print_attr(color, "Title:        ", &advisory.title);
-        self.print_attr(color, "Date:         ", &advisory.metadata.date);
-        self.print_attr(color, "ID:           ", &advisory.metadata.id);
+    fn print_metadata(&self, metadata: &rustsec::advisory::Metadata, color: Color) {
+        self.print_attr(color, "Title:        ", &metadata.title);
+        self.print_attr(color, "Date:         ", &metadata.date);
+        self.print_attr(color, "ID:           ", &metadata.id);
 
-        if let Some(url) = advisory.metadata.id.url() {
+        if let Some(url) = metadata.id.url() {
             self.print_attr(color, "URL:          ", &url);
-        } else if let Some(url) = &advisory.metadata.url {
+        } else if let Some(url) = &metadata.url {
             self.print_attr(color, "URL:          ", url);
         }
     }

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -116,7 +116,6 @@ fn advisories_found_json() {
 
     assert_eq!(vulnerabilities.len(), 1);
 
-    dbg!(&vulnerabilities[0]);
     let advisory_id = vulnerabilities[0]
         .pointer("/advisory/id")
         .unwrap()


### PR DESCRIPTION
This reverts commit e369d15194b54dd8a8155c332720cd73b0cbb97b.

This upgrade caused breaking changes to the JSON format.

Will try again with a less aggressive upgrade.