### PR TITLE
Split `-D`/`--deny` and `--deny-warnings`

### DIFF
--- a/audit.toml.example
+++ b/audit.toml.example
@@ -16,7 +16,7 @@ stale = false # Allow stale advisory DB (i.e. no commits for 90 days, default: f
 
 # Output Configuration
 [output]
-deny_warnings = ["unmaintained", "other"] # exit on error if unmaintained or other warnings are found
+deny = ["unmaintained"] # exit on error if unmaintained dependencies are found
 format = "terminal" # "terminal" (human readable report) or "json"
 quiet = false # Only print information on error
 show_tree = true # Show inverse dependency trees along with advisories (default: true)

--- a/src/config.rs
+++ b/src/config.rs
@@ -108,9 +108,9 @@ pub struct DatabaseConfig {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct OutputConfig {
-    /// Disallow any warning advisories
+    /// Disallow advisories which trigger warnings
     #[serde(default)]
-    pub deny_warnings: Vec<DenyWarningOption>,
+    pub deny: Vec<DenyOption>,
 
     /// Output format to use
     #[serde(default)]
@@ -132,56 +132,59 @@ impl OutputConfig {
 
 /// Warning kinds
 #[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Serialize, Ord)]
-pub enum DenyWarningOption {
+pub enum DenyOption {
     /// Deny all warnings
-    #[serde(rename = "all")]
-    All,
+    #[serde(rename = "warnings")]
+    Warnings,
 
-    /// Deny unmaintained warnings
+    /// Deny unmaintained dependency warnings
     #[serde(rename = "unmaintained")]
     Unmaintained,
 
-    /// Deny yanked warnings
+    /// Deny unsound dependency warnings
+    #[serde(rename = "unsound")]
+    Unsound,
+
+    /// Deny yanked dependency warnings
     #[serde(rename = "yanked")]
     Yanked,
-
-    /// Deny other warnings
-    #[serde(rename = "other")]
-    Other,
 }
 
-impl DenyWarningOption {
+impl DenyOption {
+    /// Get all of the possible warnings to be denied
+    pub fn all() -> Vec<Self> {
+        vec![
+            DenyOption::Warnings,
+            DenyOption::Unmaintained,
+            DenyOption::Unsound,
+            DenyOption::Yanked,
+        ]
+    }
     /// Get the warning::Kind that corresponds to self, if applicable
     pub fn get_warning_kind(self) -> Option<warning::Kind> {
         match self {
-            DenyWarningOption::All => None,
-            DenyWarningOption::Other => None,
-            DenyWarningOption::Unmaintained => Some(warning::Kind::Unmaintained),
-            DenyWarningOption::Yanked => Some(warning::Kind::Yanked),
+            DenyOption::Warnings => None,
+            DenyOption::Unmaintained => Some(warning::Kind::Unmaintained),
+            DenyOption::Unsound => Some(warning::Kind::Unsound),
+            DenyOption::Yanked => Some(warning::Kind::Yanked),
         }
     }
 }
 
-impl FromStr for DenyWarningOption {
+impl FromStr for DenyOption {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Error> {
         match s {
-            "unmaintained" => Ok(DenyWarningOption::Unmaintained),
-            "yanked" => Ok(DenyWarningOption::Yanked),
-            "other" => Ok(DenyWarningOption::Other),
-            "all" => Ok(DenyWarningOption::All),
+            "warnings" => Ok(DenyOption::Warnings),
+            "unmaintained" => Ok(DenyOption::Unmaintained),
+            "unsound" => Ok(DenyOption::Unsound),
+            "yanked" => Ok(DenyOption::Yanked),
             other => Err(Error::new(
                 ErrorKind::Parse,
-                &format!("invalid deny-warnings option: {}", other),
+                &format!("invalid deny option: {}", other),
             )),
         }
-    }
-}
-
-impl Default for DenyWarningOption {
-    fn default() -> Self {
-        DenyWarningOption::All
     }
 }
 

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -1,7 +1,7 @@
 //! Presenter for `rustsec::Report` information.
 
 use crate::{
-    config::{DenyWarningOption, OutputConfig, OutputFormat},
+    config::{DenyOption, OutputConfig, OutputFormat},
     prelude::*,
 };
 use abscissa_core::terminal::{
@@ -37,7 +37,7 @@ impl Presenter {
         Self {
             displayed_packages: Set::new(),
             deny_warning_kinds: config
-                .deny_warnings
+                .deny
                 .iter()
                 .filter_map(|k| k.get_warning_kind())
                 .collect(),
@@ -100,11 +100,8 @@ impl Presenter {
         // Print out any self-advisories
         if !self_advisories.is_empty() {
             let msg = "This copy of cargo-audit has known advisories!";
-            if self
-                .config
-                .deny_warnings
-                .contains(&DenyWarningOption::Other)
-            {
+
+            if self.config.deny.contains(&DenyOption::Warnings) {
                 status_err!(msg);
             } else {
                 status_warn!(msg);
@@ -113,11 +110,7 @@ impl Presenter {
             for advisory in self_advisories {
                 self.print_metadata(
                     &advisory.metadata,
-                    self.warning_color(
-                        self.config
-                            .deny_warnings
-                            .contains(&DenyWarningOption::Other),
-                    ),
+                    self.warning_color(self.config.deny.contains(&DenyOption::Warnings)),
                 );
             }
             println!();
@@ -165,11 +158,7 @@ impl Presenter {
             let upgrade_msg = "upgrade cargo-audit to the latest version: \
                                cargo install --force cargo-audit";
 
-            if self
-                .config
-                .deny_warnings
-                .contains(&DenyWarningOption::Other)
-            {
+            if self.config.deny.contains(&DenyOption::Warnings) {
                 status_err!(upgrade_msg);
                 exit_with_failure = true;
             } else {


### PR DESCRIPTION
Changing `--deny-warnings` to take an argument is a breaking change that might catch people off guard.

This splits the parameterized `-D`/`--deny` from `--deny-warnings`, marking the latter as legacy and itself spitting out a warning.

This also aligns the "deny all warnings" option to be `-D warnings` or `--deny warnings` ala other Rust tooling (e.g. RUSTFLAGS/clippy).