### PR TITLE
v0.13.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           override: true
       - name: Run cargo audit
         run: >
-          cargo run -- audit --deny-warnings all
+          cargo run -- audit -D warnings
           --ignore RUSTSEC-2020-0016
           --ignore RUSTSEC-2020-0036
           --ignore RUSTSEC-2020-0053

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.13.0 (2020-10-26)
+## 0.13.1 (2020-10-27)
+### Changed
+- Split `-D`/`--deny` and `--deny-warnings` ([#278])
+- Bump `rustsec` crate to v0.22.2 ([#277])
+
+### Fixed
+- JSON serialization ([#277])
+
+[#278]: https://github.com/RustSec/cargo-audit/pull/278
+[#277]: https://github.com/RustSec/cargo-audit/pull/277
+
+## 0.13.0 (2020-10-26) [YANKED]
 ### Added
 - Support for project specific config directories ([#252]) 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,7 @@ checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
 
 [[package]]
 name = "cargo-audit"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "abscissa_core",
  "gumdrop",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "cargo-audit"
 description = "Audit Cargo.lock for crates with security vulnerabilities"
-version     = "0.13.0"
+version     = "0.13.1"
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"


### PR DESCRIPTION
### Changed
- Split `-D`/`--deny` and `--deny-warnings` ([#278])
- Bump `rustsec` crate to v0.22.2 ([#277])

### Fixed
- JSON serialization ([#277])

[#278]: https://github.com/RustSec/cargo-audit/pull/278
[#277]: https://github.com/RustSec/cargo-audit/pull/277