### PR TITLE
Warn about unsound dependencies by default

### DIFF
--- a/audit.toml.example
+++ b/audit.toml.example
@@ -4,7 +4,7 @@
 
 [advisories]
 ignore = [] # advisory IDs to ignore e.g. ["RUSTSEC-2019-0001", ...]
-informational_warnings = ["unmaintained"] # warn for categories of informational advisories
+informational_warnings = ["unmaintained", "unsound"] # warn for categories of informational advisories
 severity_threshold = "low" # CVSS severity ("none", "low", "medium", "high", "critical")
 
 # Advisory Database Configuration

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,8 +58,11 @@ impl AuditConfig {
         if let Some(informational_warnings) = &self.advisories.informational_warnings {
             settings.informational_warnings = informational_warnings.clone();
         } else {
-            // Alert for unmaintained packages by default
-            settings.informational_warnings = vec![advisory::Informational::Unmaintained];
+            // Alert for unmaintained and unsound packages by default
+            settings.informational_warnings = vec![
+                advisory::Informational::Unmaintained,
+                advisory::Informational::Unsound,
+            ];
         }
 
         settings


### PR DESCRIPTION
Based on the discussion in #318 add "unsound" to the default list of informational warnings.
Also update the example config file to represent the same change.