### PR TITLE
v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.14.0 (2021-03-07)
+### Changed
+- When running in no-fetch mode, allow accessing a non-git repo ([#315])
+- Enable informational warnings with deny ([#320])
+- Bump `rustsec` dependency to v0.23 ([#327]) 
+- MSRV 1.46+ ([#327])
+
+[#315]: https://github.com/RustSec/cargo-audit/pull/315
+[#320]: https://github.com/RustSec/cargo-audit/pull/320
+[#327]: https://github.com/RustSec/cargo-audit/pull/327
+
 ## 0.13.1 (2020-10-27)
 ### Changed
 - Split `-D`/`--deny` and `--deny-warnings` ([#278])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
 
 [[package]]
 name = "cargo-audit"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "abscissa_core",
  "gumdrop",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "cargo-audit"
 description = "Audit Cargo.lock for crates with security vulnerabilities"
-version     = "0.13.1"
+version     = "0.14.0"
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/main/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/cargo-audit/0.13.0"
+    html_root_url = "https://docs.rs/cargo-audit/0.14.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]


### PR DESCRIPTION
### Changed
- When running in no-fetch mode, allow accessing a non-git repo ([#315])
- Enable informational warnings with deny ([#320])
- Bump `rustsec` dependency to v0.23 ([#327]) 
- MSRV 1.46+ ([#327])

[#315]: https://github.com/RustSec/cargo-audit/pull/315
[#320]: https://github.com/RustSec/cargo-audit/pull/320
[#327]: https://github.com/RustSec/cargo-audit/pull/327