### PR TITLE
Build weekly Docker images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,36 @@
+name: Publish Docker Image
+
+# Build on push to main and every week (sunday at 13:37)
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '37 13 * * 0'
+
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: -D warnings
+  DOCKER_IMAGE: rustsec/cargo-audit
+
+jobs:
+  # Build a docker image based on rust:latest, which installs latest cargo-audit from crates.io.
+  #
+  # Note: Right now we do not create versioned releases, the `latest` tag will always contain
+  #       the latest crates.io release! This is ideal for use in CI.
+  build_and_push:
+    name: Build and publish Docker image
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'RustSec' }}  # Do not run on forks, they can't push
+    steps:
+      - name: Create Dockerfile
+        run: |
+          echo "FROM rust:latest" > Dockerfile
+          echo "RUN apt-get update && apt-get install -y --no-install-recommends cmake && rm -rf /var/lib/apt/lists/*" >> Dockerfile
+          echo "RUN cargo install -f cargo-audit" >> Dockerfile
+          cat Dockerfile
+      - name: Build Docker image
+        run: docker build --no-cache -t ${DOCKER_IMAGE}:latest .
+      - name: Push Docker image
+        run: |
+          docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}" && \
+          docker push ${DOCKER_IMAGE}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Latest Version][crate-image]][crate-link]
 [![Build Status][build-image]][build-link]
+[![Docker Image][docker-image]][docker-link]
 [![Safety Dance][safety-image]][safety-link]
 ![MSRV][rustc-image]
 ![Apache 2.0 OR MIT licensed][license-image]
@@ -96,6 +97,8 @@ additional terms or conditions.
 [crate-link]: https://crates.io/crates/cargo-audit
 [build-image]: https://github.com/rustsec/cargo-audit/workflows/CI/badge.svg?branch=main&event=push
 [build-link]: https://github.com/RustSec/cargo-audit/actions?query=workflow:CI+branch:main
+[docker-image]: https://img.shields.io/docker/pulls/rustsec/cargo-audit.svg
+[docker-link]: https://hub.docker.com/u/rustsec/cargo-audit
 [license-image]: https://img.shields.io/badge/license-Apache2.0%2FMIT-blue.svg
 [rustc-image]: https://img.shields.io/badge/rustc-1.46+-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg


### PR DESCRIPTION
Build a docker image based on `rust:latest`, which installs latest cargo-audit from crates.io.

Note: This will not create versioned releases, the `latest` tag will always contain the latest crates.io release! This is ideal for use in CI, where you want to keep up to date. Always tagging the currently built image with the version would be easy, but it means that only the latest released version would get image updates, which is not ideal. A setup where multiple versions are regularly re-built, would be more complex and is out of scope for now.

Images are automatically built and pushed every Sunday at 13:37 UTC, and when pushing to `main`. The job does not run on forks (because the push would fail).

I think this should be ready now, but you'll still need to set up the `DOCKER_USERNAME` and `DOCKER_PASSWORD` secret variables. Make sure to create a dummy account for uploading.

Refs #66.