### PR TITLE
Generate release builds with github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,12 +64,12 @@ jobs:
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@v1.0.7
         with:
           toolchain: stable
           profile: minimal
           override: true
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@v1.0.3
         name: Build
         with:
           use-cross: ${{ matrix.cross }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           use-cross: ${{ matrix.cross }}
           command: build
-          args: --release --features fix --target ${{ matrix.target }}
+          args: --release --locked --features fix --target ${{ matrix.target }}
       - name: Package
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,108 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*.*.*
+
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: -D warnings
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        name:
+          - linux-x86-64-gnu
+          - linux-x86-64-musl
+          - linux-armv7-gnu
+          - linux-arm64-gnu
+          - mac-x86-64
+          - windows-x86-64
+        include:
+          - name: linux-x86-64-gnu
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            cross: false
+
+          - name: linux-x86-64-musl
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            cross: true
+
+          - name: linux-armv7-gnu
+            os: ubuntu-latest
+            target: armv7-unknown-linux-gnueabihf
+            cross: true
+
+          - name: linux-arm64-gnu
+            os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            cross: true
+
+          - name: mac-x86-64
+            os: macos-latest
+            target: x86-64-apple-darwin
+            cross: false
+
+          - name: windows-x86-64
+            os: windows-latest
+            target: x86-64-pc-windows-msvc
+            cross: false
+
+    name: Binaries for ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - uses: actions-rs/cargo@v1
+        name: Build
+        with:
+          use-cross: ${{ matrix.cross }}
+          command: build
+          args: --release --features fix --target ${{ matrix.target }}
+      - name: Package
+        shell: bash
+        run: |
+          set -eux
+          bin="target/${{ matrix.target }}/release/cargo-audit"
+          version=$(echo "${{ github.ref }}" | cut -d/ -f3)
+          dst="cargo-audit-${version}-${{ matrix.target }}"
+          mkdir "$dst"
+          mv "$bin" "$dst/"
+          mv README.md CHANGELOG.md LICENSE-APACHE LICENSE-MIT "$dst/"
+      - name: Archive (tar)
+        if: '! startsWith(matrix.name, ''windows-'')'
+        shell: bash
+        run: |
+          version=$(echo "${{ github.ref }}" | cut -d/ -f3)
+          dst="cargo-audit-${version}-${{ matrix.target }}"
+          tar cavf "$dst.tar.gz" "$dst"
+      - name: Archive (zip)
+        if: startsWith(matrix.name, 'windows-')
+        shell: bash
+        run: |
+          version=$(echo "${{ github.ref }}" | cut -d/ -f3)
+          dst="cargo-audit-${version}-${{ matrix.target }}"
+          7z a "$dst.zip" "$dst"
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            cargo-audit-*.tar.gz
+            cargo-audit-*.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
       - uses: softprops/action-gh-release@91409e712cf565ce9eff10c87a8d1b11b81757ae
         with:
           files: |
-            cargo-audit-*.tar.gz
+            cargo-audit-*.tgz
             cargo-audit-*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
           set -eux
           bin="target/${{ matrix.target }}/release/cargo-audit"
           version=$(echo "${{ github.ref }}" | cut -d/ -f3)
-          dst="cargo-audit-${version}-${{ matrix.target }}"
+          dst="cargo-audit-${{ matrix.target }}-${version}"
           mkdir "$dst"
           mv "$bin" "$dst/"
           mv README.md CHANGELOG.md LICENSE-APACHE LICENSE-MIT "$dst/"
@@ -90,14 +90,14 @@ jobs:
         shell: bash
         run: |
           version=$(echo "${{ github.ref }}" | cut -d/ -f3)
-          dst="cargo-audit-${version}-${{ matrix.target }}"
-          tar cavf "$dst.tar.gz" "$dst"
+          dst="cargo-audit-${{ matrix.target }}-${version}"
+          tar cavf "$dst.tgz" "$dst"
       - name: Archive (zip)
         if: startsWith(matrix.name, 'windows-')
         shell: bash
         run: |
           version=$(echo "${{ github.ref }}" | cut -d/ -f3)
-          dst="cargo-audit-${version}-${{ matrix.target }}"
+          dst="cargo-audit-${{ matrix.target }}-${version}"
           7z a "$dst.zip" "$dst"
       - uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,12 +64,12 @@ jobs:
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
-      - uses: actions-rs/toolchain@v1.0.7
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
         with:
           toolchain: stable
           profile: minimal
           override: true
-      - uses: actions-rs/cargo@v1.0.3
+      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505
         name: Build
         with:
           use-cross: ${{ matrix.cross }}
@@ -99,7 +99,7 @@ jobs:
           version=$(echo "${{ github.ref }}" | cut -d/ -f3)
           dst="cargo-audit-${{ matrix.target }}-${version}"
           7z a "$dst.zip" "$dst"
-      - uses: softprops/action-gh-release@v1
+      - uses: softprops/action-gh-release@91409e712cf565ce9eff10c87a8d1b11b81757ae
         with:
           files: |
             cargo-audit-*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,12 +43,12 @@ jobs:
 
           - name: mac-x86-64
             os: macos-latest
-            target: x86-64-apple-darwin
+            target: x86_64-apple-darwin
             cross: false
 
           - name: windows-x86-64
             os: windows-latest
-            target: x86-64-pc-windows-msvc
+            target: x86_64-pc-windows-msvc
             cross: false
 
     name: Binaries for ${{ matrix.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,9 @@ jobs:
         shell: bash
         run: |
           set -eux
-          bin="target/${{ matrix.target }}/release/cargo-audit"
+          ext=""
+          [[ "${{ matrix.name }}" == windows-* ]] && ext=".exe"
+          bin="target/${{ matrix.target }}/release/cargo-audit${ext}"
           version=$(echo "${{ github.ref }}" | cut -d/ -f3)
           dst="cargo-audit-${{ matrix.target }}-${version}"
           mkdir "$dst"


### PR DESCRIPTION
Submitted for consideration re #66

Obviously not end-to-end tested against this repo.

Some choices/questions:

- I've named the Windows and macOS sections with their isa (x86-64) even though that's currently the only option, in the optic that perhaps there would eventually be builds for Windows ARM or Apple Silicon.

- I've selected tar.gz as the archive format (zip on windows) as it's most common but it could be xz or zstd... as you wish

- I've included the readme, changelog, and license files in the archive. Maybe that's not necessary? Or should the audit.toml.example file be included as well for even more of a batteries-included ux?

- Should the build be done with `--locked` to respect the lockfile?

- Should checksums be generated? (not sure how to do that due to the job layout / parallelism though)

- Though this is a 1st party github service, some of the actions used are not (from action-rs and softprops). I'm sure it would be possible to avoid these, though that's beyond the level of effort I'm okay expending for this tbqh.