### PR TITLE
v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.14.1 (2021-04-29)
+### Added
+- Generate release builds with github actions ([#337])
+
+### Changed
+- Bump rustsec from 0.23.2 to 0.23.3 ([#333])
+
+[#333]: https://github.com/RustSec/cargo-audit/pull/333
+[#337]: https://github.com/RustSec/cargo-audit/pull/337
+
 ## 0.14.0 (2021-03-07)
 ### Changed
 - When running in no-fetch mode, allow accessing a non-git repo ([#315])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
 
 [[package]]
 name = "cargo-audit"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "abscissa_core",
  "gumdrop",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "cargo-audit"
 description = "Audit Cargo.lock for crates with security vulnerabilities"
-version     = "0.14.0"
+version     = "0.14.1"
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://rustsec.org"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustSec/logos/main/rustsec-logo-lg.png",
-    html_root_url = "https://docs.rs/cargo-audit/0.14.0"
+    html_root_url = "https://docs.rs/cargo-audit/0.14.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]


### PR DESCRIPTION
### Added
- Generate release builds with github actions ([#337])

### Changed
- Bump rustsec from 0.23.2 to 0.23.3 ([#333])

[#333]: https://github.com/RustSec/cargo-audit/pull/333
[#337]: https://github.com/RustSec/cargo-audit/pull/337